### PR TITLE
Remove unused help files

### DIFF
--- a/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/InstancesToRun/help-suspendOrTerminate.jelly
+++ b/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/InstancesToRun/help-suspendOrTerminate.jelly
@@ -1,3 +1,0 @@
-<div>
-  If selected, when the build finishes, suspend the instances rather than terminate them.
-</div>

--- a/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/help-zones.html
+++ b/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/help-zones.html
@@ -1,3 +1,0 @@
-<div>
-    OpenStack region to restrict spawning of slaves to it.
-</div>

--- a/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate/help-imageNameRegex.html
+++ b/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate/help-imageNameRegex.html
@@ -1,3 +1,0 @@
-<div>
-  Regular expression to be used to select images by name. See <a href="http://docs.oracle.com/javase/tutorial/essential/regex/">docs</a> for more details.
-</div>

--- a/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate/help-initScript.html
+++ b/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate/help-initScript.html
@@ -1,4 +1,0 @@
-<div>
-    This shell script gets executed right after Jenkins connects to a new cloud instance.
-    This is a good place to execute a system set up, such as installing some packages.
-</div>

--- a/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate/help-jenkinsUser.html
+++ b/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate/help-jenkinsUser.html
@@ -1,3 +1,0 @@
-<div>
-  The user the Jenkins slave process will run as. Defaults to "jenkins".
-</div>

--- a/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate/help-locationId.html
+++ b/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate/help-locationId.html
@@ -1,3 +1,0 @@
-<div>
-  Location ID on the provider where this slave template will be deployed, such as "us-east-1" on AWS EC2. If none is selected, jclouds will automatically choose an available one.
-</div>


### PR DESCRIPTION
I verified they are indeed unused:
```
for f in `find openstack-cloud/ -iname help-*`; do echo $f; grep -r `sed 's^.*help-\(.*\)[.].*^\1^' <<< $f` openstack-cloud/src/main/resources/; done`
```