### PR TITLE
Allow floating IP allocation

### DIFF
--- a/openstack-cloud/src/main/java/jenkins/plugins/openstack/compute/JCloudsCloud.java
+++ b/openstack-cloud/src/main/java/jenkins/plugins/openstack/compute/JCloudsCloud.java
@@ -137,7 +137,7 @@ public class JCloudsCloud extends Cloud {
         return retentionTime == 0 ? DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES : retentionTime;
     }
 
-    /*package*/ boolean isFloatingIps() {
+    public boolean isFloatingIps() {
         return floatingIps;
     }
 

--- a/openstack-cloud/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
+++ b/openstack-cloud/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
@@ -199,6 +199,11 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
             options.securityGroups(csvToArray(securityGroups));
         }
 
+        if (cloud.isFloatingIps()) {
+            LOGGER.info("Asking for floating IP");
+            options.as(NovaTemplateOptions.class).autoAssignFloatingIp(true);
+        }
+
         if (!Strings.isNullOrEmpty(keyPairName)) {
             LOGGER.info("Setting keyPairName to " + keyPairName);
             options.keyPairName(keyPairName);

--- a/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/config.jelly
+++ b/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/config.jelly
@@ -22,6 +22,9 @@
         <f:entry title="Retention Time" field="retentionTime">
             <f:textbox default="30" />
         </f:entry>
+        <f:entry title="Associate floating IP" field="floatingIps">
+            <f:checkbox/>
+        </f:entry>
         <f:entry title="Default Init Script Timeout" field="scriptTimeout">
             <f:textbox default="600000"/>
         </f:entry>

--- a/openstack-cloud/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudInsideJenkinsLiveTest.java
+++ b/openstack-cloud/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudInsideJenkinsLiveTest.java
@@ -27,7 +27,7 @@ public class JCloudsCloudInsideJenkinsLiveTest extends HudsonTestCase {
         // TODO: this may need to vary per test
         cloud = new JCloudsCloud("profile", fixture.getIdentity(), fixture.getCredential(),
                 fixture.getEndpoint(), 1, DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES, 600 * 1000, 600 * 1000, null,
-                Collections.<JCloudsSlaveTemplate>emptyList());
+                Collections.<JCloudsSlaveTemplate>emptyList(), true);
     }
 
     public void testDoTestConnectionCorrectCredentialsEtc() throws IOException {

--- a/openstack-cloud/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudLiveTest.java
+++ b/openstack-cloud/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudLiveTest.java
@@ -28,7 +28,7 @@ public class JCloudsCloudLiveTest extends TestCase {
         // TODO: this may need to vary per test
         cloud = new JCloudsCloud("profile", fixture.getIdentity(), fixture.getCredential(),
                 fixture.getEndpoint(), 1, DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES, 600 * 1000, 600 * 1000, null,
-                Collections.<JCloudsSlaveTemplate>emptyList());
+                Collections.<JCloudsSlaveTemplate>emptyList(), true);
     }
 
     public void testDoTestConnectionCorrectCredentialsEtc() throws IOException {

--- a/openstack-cloud/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudTest.java
+++ b/openstack-cloud/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudTest.java
@@ -53,16 +53,16 @@ public class JCloudsCloudTest {
     public void testConfigRoundtrip() throws Exception {
 
         JCloudsCloud original = new JCloudsCloud("openstack-profile", "identity", "credential", "endPointUrl", 1, DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES,
-                600 * 1000, 600 * 1000, null, Collections.<JCloudsSlaveTemplate>emptyList());
+                600 * 1000, 600 * 1000, null, Collections.<JCloudsSlaveTemplate>emptyList(), true);
 
         j.getInstance().clouds.add(original);
         j.submit(j.createWebClient().goTo("configure").getFormByName("config"));
 
         j.assertEqualBeans(original, j.getInstance().clouds.getByName("openstack-profile"),
-                "identity,credential,endPointUrl,instanceCap,retentionTime");
+                "identity,credential,endPointUrl,instanceCap,retentionTime,floatingIps");
 
         j.assertEqualBeans(original, JCloudsCloud.getByName("openstack-profile"),
-                "identity,credential,endPointUrl,instanceCap,retentionTime");
+                "identity,credential,endPointUrl,instanceCap,retentionTime,floatingIps");
     }
 
 }

--- a/openstack-cloud/src/test/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplateTest.java
+++ b/openstack-cloud/src/test/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplateTest.java
@@ -22,7 +22,7 @@ public class JCloudsSlaveTemplateTest extends HudsonTestCase {
         templates.add(originalTemplate);
 
         JCloudsCloud originalCloud = new JCloudsCloud("aws-profile", "identity", "credential", "endPointUrl", 1, DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES,
-                600 * 1000, 600 * 1000, null, templates);
+                600 * 1000, 600 * 1000, null, templates, true);
 
         hudson.clouds.add(originalCloud);
         submit(createWebClient().goTo("configure").getFormByName("config"));


### PR DESCRIPTION
If I understand correctly, nova can be configured to either allocate one automatically or user have to ask for FIP explicitly. All OS instances I have at hand require to ask for FIP so this is a critical use-case for me. On the other hand I am opened to do this by default without user configuration assuming it does not blow up for instances that allocate FIP by default.

@mavlyutov, WDYT? How it works for you without explicit FIP allocation?