### PR TITLE
JENKINS-29136 fix NPE in getRetentionTime().

### DIFF
--- a/openstack-cloud/src/main/java/jenkins/plugins/openstack/compute/CloudInstanceDefaults.java
+++ b/openstack-cloud/src/main/java/jenkins/plugins/openstack/compute/CloudInstanceDefaults.java
@@ -1,0 +1,8 @@
+package jenkins.plugins.openstack.compute;
+
+/**
+ * Holds default values for Cloud Instances, like default retention time.
+ */
+final class CloudInstanceDefaults {
+    public static final int DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES = 30;
+}

--- a/openstack-cloud/src/main/java/jenkins/plugins/openstack/compute/JCloudsCloud.java
+++ b/openstack-cloud/src/main/java/jenkins/plugins/openstack/compute/JCloudsCloud.java
@@ -54,6 +54,8 @@ import shaded.com.google.common.collect.ImmutableSortedSet;
 import shaded.com.google.common.collect.Iterables;
 import shaded.com.google.common.io.Closeables;
 
+import static jenkins.plugins.openstack.compute.CloudInstanceDefaults.DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES;
+
 /**
  * The JClouds version of the Jenkins Cloud.
  *
@@ -116,10 +118,11 @@ public class JCloudsCloud extends Cloud {
     }
 
     /**
-     * Get the retention time, defaulting to 30 minutes.
+     * Get the retention time in minutes or default value from CloudInstanceDefaults if not set.
+     * @see CloudInstanceDefaults#DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES
      */
     public int getRetentionTime() {
-        return retentionTime == 0 ? 30 : retentionTime;
+        return retentionTime == 0 ? DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES : retentionTime;
     }
 
     static final Iterable<Module> MODULES = ImmutableSet.<Module>of(new SshjSshClientModule(), new JDKLoggingModule() {

--- a/openstack-cloud/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlave.java
+++ b/openstack-cloud/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlave.java
@@ -18,6 +18,8 @@ import org.jclouds.compute.ComputeService;
 import org.jclouds.compute.domain.NodeMetadata;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import static jenkins.plugins.openstack.compute.CloudInstanceDefaults.DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES;
+
 /**
  * Jenkins Slave node - managed by JClouds.
  *
@@ -99,15 +101,19 @@ public class JCloudsSlave extends AbstractCloudSlave {
 
     /**
      * Get the retention time for this slave, defaulting to the parent cloud's if not set.
+     * Sometime parent cloud cannot be determined (returns Null as I see), in which case this method will
+     * return default value set in CloudInstanceDefaults.
      *
      * @return overrideTime
+     * @see CloudInstanceDefaults#DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES
      */
     public int getRetentionTime() {
         if (overrideRetentionTime > 0) {
             return overrideRetentionTime;
-        } else {
-            return JCloudsCloud.getByName(cloudName).getRetentionTime();
         }
+
+        JCloudsCloud cloud = JCloudsCloud.getByName(cloudName);
+        return cloud == null ? DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES : cloud.getRetentionTime();
     }
 
     /**

--- a/openstack-cloud/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudInsideJenkinsLiveTest.java
+++ b/openstack-cloud/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudInsideJenkinsLiveTest.java
@@ -9,6 +9,8 @@ import java.util.Map;
 import org.jclouds.ssh.SshKeys;
 import org.jvnet.hudson.test.HudsonTestCase;
 
+import static jenkins.plugins.openstack.compute.CloudInstanceDefaults.DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES;
+
 public class JCloudsCloudInsideJenkinsLiveTest extends HudsonTestCase {
 
     private ComputeTestFixture fixture;
@@ -24,7 +26,7 @@ public class JCloudsCloudInsideJenkinsLiveTest extends HudsonTestCase {
 
         // TODO: this may need to vary per test
         cloud = new JCloudsCloud("profile", fixture.getIdentity(), fixture.getCredential(),
-                fixture.getEndpoint(), 1, 30, 600 * 1000, 600 * 1000, null,
+                fixture.getEndpoint(), 1, DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES, 600 * 1000, 600 * 1000, null,
                 Collections.<JCloudsSlaveTemplate>emptyList());
     }
 

--- a/openstack-cloud/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudLiveTest.java
+++ b/openstack-cloud/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudLiveTest.java
@@ -10,6 +10,8 @@ import junit.framework.TestCase;
 
 import org.jclouds.ssh.SshKeys;
 
+import static jenkins.plugins.openstack.compute.CloudInstanceDefaults.DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES;
+
 public class JCloudsCloudLiveTest extends TestCase {
 
     private ComputeTestFixture fixture;
@@ -25,7 +27,7 @@ public class JCloudsCloudLiveTest extends TestCase {
 
         // TODO: this may need to vary per test
         cloud = new JCloudsCloud("profile", fixture.getIdentity(), fixture.getCredential(),
-                fixture.getEndpoint(), 1, 30, 600 * 1000, 600 * 1000, null,
+                fixture.getEndpoint(), 1, DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES, 600 * 1000, 600 * 1000, null,
                 Collections.<JCloudsSlaveTemplate>emptyList());
     }
 

--- a/openstack-cloud/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudTest.java
+++ b/openstack-cloud/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudTest.java
@@ -1,5 +1,6 @@
 package jenkins.plugins.openstack.compute;
 
+import static jenkins.plugins.openstack.compute.CloudInstanceDefaults.DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -51,7 +52,7 @@ public class JCloudsCloudTest {
     @Test
     public void testConfigRoundtrip() throws Exception {
 
-        JCloudsCloud original = new JCloudsCloud("openstack-profile", "identity", "credential", "endPointUrl", 1, 30,
+        JCloudsCloud original = new JCloudsCloud("openstack-profile", "identity", "credential", "endPointUrl", 1, DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES,
                 600 * 1000, 600 * 1000, null, Collections.<JCloudsSlaveTemplate>emptyList());
 
         j.getInstance().clouds.add(original);

--- a/openstack-cloud/src/test/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplateTest.java
+++ b/openstack-cloud/src/test/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplateTest.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import org.jvnet.hudson.test.HudsonTestCase;
 
+import static jenkins.plugins.openstack.compute.CloudInstanceDefaults.DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES;
+
 /**
  * @author Vijay Kiran
  */
@@ -19,7 +21,7 @@ public class JCloudsSlaveTemplateTest extends HudsonTestCase {
         List<JCloudsSlaveTemplate> templates = new ArrayList<JCloudsSlaveTemplate>();
         templates.add(originalTemplate);
 
-        JCloudsCloud originalCloud = new JCloudsCloud("aws-profile", "identity", "credential", "endPointUrl", 1, 30,
+        JCloudsCloud originalCloud = new JCloudsCloud("aws-profile", "identity", "credential", "endPointUrl", 1, DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES,
                 600 * 1000, 600 * 1000, null, templates);
 
         hudson.clouds.add(originalCloud);


### PR DESCRIPTION
I documented the bug here: https://issues.jenkins-ci.org/browse/JENKINS-29136

this NPE was preventing jenkins workers from being deleted when they should have been.

I added a defaults class that will be used when parent cloud cannot be resolved
due to whatever reason.