### PR TITLE
Corrects user identity help text

### DIFF
--- a/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/help-identity.html
+++ b/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/help-identity.html
@@ -1,3 +1,3 @@
 <div>
-  Identity of the user to start the machine (<tt>USER_NAME:TENANT_NAME</tt>).
+  Identity of the user to start the machine (<tt>TENANT_NAME:USER_NAME</tt>).
 </div>


### PR DESCRIPTION
The help text for "User Identity" states the follow.
"Identity of the user to start the machine (USER_NAME:TENANT_NAME)."

In practice, you must specify TENANT_NAME:USER_NAME. The help text should read...
"Identity of the user to start the machine (TENANT_NAME:USER_NAME)."