### PR TITLE
Adds support for floating IP pools

### DIFF
--- a/openstack-cloud/src/main/java/jenkins/plugins/openstack/compute/JCloudsCloud.java
+++ b/openstack-cloud/src/main/java/jenkins/plugins/openstack/compute/JCloudsCloud.java
@@ -78,6 +78,7 @@ public class JCloudsCloud extends Cloud {
     private final int retentionTime;
     public final int instanceCap;
     public final List<JCloudsSlaveTemplate> templates;
+    public final int sshLaunchDelay;
     public final int scriptTimeout;
     public final int startTimeout;
     public final String zone;
@@ -105,7 +106,7 @@ public class JCloudsCloud extends Cloud {
 
     @DataBoundConstructor @Restricted(DoNotUse.class)
     public JCloudsCloud(final String profile, final String identity, final String credential, final String endPointUrl, final int instanceCap,
-                        final int retentionTime, final int scriptTimeout, final int startTimeout, final String zone, final List<JCloudsSlaveTemplate> templates,
+                        final int retentionTime, final int sshLaunchDelay, final int scriptTimeout, final int startTimeout, final String zone, final List<JCloudsSlaveTemplate> templates,
                         final boolean floatingIps
     ) {
         super(Util.fixEmptyAndTrim(profile));
@@ -115,6 +116,7 @@ public class JCloudsCloud extends Cloud {
         this.endPointUrl = Util.fixEmptyAndTrim(endPointUrl);
         this.instanceCap = instanceCap;
         this.retentionTime = retentionTime;
+        this.sshLaunchDelay = sshLaunchDelay;
         this.scriptTimeout = scriptTimeout;
         this.startTimeout = startTimeout;
         this.templates = Objects.firstNonNull(templates, Collections.<JCloudsSlaveTemplate> emptyList());
@@ -135,6 +137,10 @@ public class JCloudsCloud extends Cloud {
      */
     public int getRetentionTime() {
         return retentionTime == 0 ? DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES : retentionTime;
+    }
+
+    public int getSshLaunchDelay() {
+        return sshLaunchDelay;
     }
 
     public boolean isFloatingIps() {
@@ -398,6 +404,10 @@ public class JCloudsCloud extends Cloud {
                     return FormValidation.ok();
             } catch (NumberFormatException e) {
             }
+            return FormValidation.validateNonNegativeInteger(value);
+        }
+
+        public FormValidation doCheckSshLaunchDelay(@QueryParameter String value) {
             return FormValidation.validateNonNegativeInteger(value);
         }
 

--- a/openstack-cloud/src/main/java/jenkins/plugins/openstack/compute/JCloudsCloud.java
+++ b/openstack-cloud/src/main/java/jenkins/plugins/openstack/compute/JCloudsCloud.java
@@ -45,6 +45,7 @@ import org.jclouds.openstack.nova.v2_0.NovaApiMetadata;
 import org.jclouds.sshj.config.SshjSshClientModule;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -407,6 +408,7 @@ public class JCloudsCloud extends Cloud {
             return FormValidation.validateNonNegativeInteger(value);
         }
 
+        @Restricted(NoExternalUse.class)
         public FormValidation doCheckSshLaunchDelay(@QueryParameter String value) {
             return FormValidation.validateNonNegativeInteger(value);
         }

--- a/openstack-cloud/src/main/java/jenkins/plugins/openstack/compute/JCloudsLauncher.java
+++ b/openstack-cloud/src/main/java/jenkins/plugins/openstack/compute/JCloudsLauncher.java
@@ -55,12 +55,8 @@ public class JCloudsLauncher extends ComputerLauncher {
             int sshLaunchDelay = cloud.getSshLaunchDelay();
 
             if (sshLaunchDelay > 0) {
-                try {
-                    LOGGER.info(String.format("Delaying launch for %s milliseconds", sshLaunchDelay));
-                    Thread.sleep(sshLaunchDelay);
-                } catch (InterruptedException ex) {
-                    Thread.currentThread().interrupt();
-                }
+                LOGGER.info(String.format("Delaying launch for %s milliseconds", sshLaunchDelay));
+                Thread.sleep(sshLaunchDelay);
             }
 
             SSHLauncher launcher = new SSHLauncher(host, 22, slave.getCredentialsId(), slave.getJvmOptions(), null, "", "", Integer.valueOf(0), null, null);

--- a/openstack-cloud/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
+++ b/openstack-cloud/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
@@ -50,6 +50,8 @@ import org.jclouds.openstack.nova.v2_0.compute.options.NovaTemplateOptions;
 import org.jclouds.predicates.validators.DnsNameValidator;
 import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -435,6 +437,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
             return m;
         }
 
+        @Restricted(NoExternalUse.class)
         public ListBoxModel doFillFloatingIpPoolIdItems(@RelativePath("..") @QueryParameter String identity,
                                                         @RelativePath("..") @QueryParameter String credential,
                                                         @RelativePath("..") @QueryParameter String endPointUrl,

--- a/openstack-cloud/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
+++ b/openstack-cloud/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
@@ -86,6 +86,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
     public final int overrideRetentionTime;
     public final String keyPairName;
     public final String networkId;
+    public final String floatingIpPoolId;
     public final String securityGroups;
     public final String credentialsId;
     public final JCloudsCloud.SlaveType slaveType;
@@ -99,7 +100,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
     public JCloudsSlaveTemplate(final String name, final String imageId, final String hardwareId,
                                 final String labelString, final String userDataId, final String numExecutors,
                                 final boolean stopOnTerminate, final String jvmOptions, final String fsRoot, final boolean installPrivateKey,
-                                final int overrideRetentionTime, final String keyPairName, final String networkId,
+                                final int overrideRetentionTime, final String keyPairName, final String networkId, final String floatingIpPoolId,
                                 final String securityGroups, final String credentialsId, final JCloudsCloud.SlaveType slaveType, final String availabilityZone) {
 
         this.name = Util.fixEmptyAndTrim(name);
@@ -116,6 +117,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
         this.overrideRetentionTime = overrideRetentionTime;
         this.keyPairName = keyPairName;
         this.networkId = networkId;
+        this.floatingIpPoolId = floatingIpPoolId;
         this.securityGroups = securityGroups;
         this.credentialsId = credentialsId;
         this.slaveType = slaveType;
@@ -202,6 +204,11 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
         if (cloud.isFloatingIps()) {
             LOGGER.info("Asking for floating IP");
             options.as(NovaTemplateOptions.class).autoAssignFloatingIp(true);
+
+            if (!Strings.isNullOrEmpty(floatingIpPoolId)) {
+                LOGGER.info("Using floating IP pool: " + floatingIpPoolId);
+                options.as(NovaTemplateOptions.class).floatingIpPoolNames(floatingIpPoolId);
+            }
         }
 
         if (!Strings.isNullOrEmpty(keyPairName)) {
@@ -420,6 +427,46 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 
                 for (Network network : networks) {
                     m.add(String.format("%s (%s)", network.getName(), network.getId()), network.getId());
+                }
+            } catch (Exception ex) {
+                LOGGER.log(Level.SEVERE, ex.getMessage(), ex);
+            }
+
+            return m;
+        }
+
+        public ListBoxModel doFillFloatingIpPoolIdItems(@RelativePath("..") @QueryParameter String identity,
+                                                        @RelativePath("..") @QueryParameter String credential,
+                                                        @RelativePath("..") @QueryParameter String endPointUrl,
+                                                        @RelativePath("..") @QueryParameter String zone) {
+
+            ListBoxModel m = new ListBoxModel();
+
+            if (Strings.isNullOrEmpty(identity)) {
+                LOGGER.warning("identity is null or empty");
+                return m;
+            }
+            if (Strings.isNullOrEmpty(credential)) {
+                LOGGER.warning("credential is null or empty");
+                return m;
+            }
+
+            identity = Util.fixEmptyAndTrim(identity);
+            credential = Secret.fromString(credential).getPlainText();
+            endPointUrl = Util.fixEmptyAndTrim(endPointUrl);
+
+            NetworkApi networkApi = null;
+            m.add("None specified", "");
+            try {
+
+                networkApi = JCloudsCloud.na(identity, credential, endPointUrl).getNetworkApi(zone);
+
+                List<? extends Network> networks = networkApi.list().concat().toSortedList(NETWORK_COMPARATOR);
+
+                for (Network network : networks) {
+                    if (network.getExternal()) {
+                        m.add(String.format("%s (%s)", network.getName(), network.getId()), network.getName());
+                    }
                 }
             } catch (Exception ex) {
                 LOGGER.log(Level.SEVERE, ex.getMessage(), ex);

--- a/openstack-cloud/src/main/resources/index.jelly
+++ b/openstack-cloud/src/main/resources/index.jelly
@@ -1,3 +1,3 @@
 <div>
-    Allows Jenkins to build using Cloud Servers via JClouds.
+    Allows Jenkins to build using Cloud Servers in OpenStack via jclouds.
 </div>

--- a/openstack-cloud/src/main/resources/index.jelly
+++ b/openstack-cloud/src/main/resources/index.jelly
@@ -1,3 +1,3 @@
 <div>
-    Allows Jenkins to build using Cloud Servers in OpenStack via jclouds.
+    Allows Jenkins to provision build nodes in an OpenStack cloud.
 </div>

--- a/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/config.jelly
+++ b/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/config.jelly
@@ -25,6 +25,9 @@
         <f:entry title="Associate floating IP" field="floatingIps">
             <f:checkbox/>
         </f:entry>
+        <f:entry title="SSH Launch Delay" field="sshLaunchDelay">
+            <f:textbox default="0"/>
+        </f:entry>
         <f:entry title="Default Init Script Timeout" field="scriptTimeout">
             <f:textbox default="600000"/>
         </f:entry>

--- a/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/help-sshlaunchDelay.html
+++ b/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/help-sshlaunchDelay.html
@@ -1,0 +1,5 @@
+<div>
+  Number of milliseconds to wait before attempting to launch the slave. This
+  can be useful if it takes a bit of time before the instance is ready to
+  accept SSH connections. Defaults to 0.
+</div>

--- a/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate/config.jelly
+++ b/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate/config.jelly
@@ -9,7 +9,7 @@
         <f:textbox/>
       </f:entry>
     </f:section>
-    
+
     <f:section title="Cloud Server Options">
         <f:entry title="Image" field="imageId">
             <f:select />
@@ -18,6 +18,9 @@
             <f:select />
         </f:entry>
         <f:entry title="Network" field="networkId">
+            <f:select />
+        </f:entry>
+        <f:entry title="Floating IP Pool" field="floatingIpPoolId">
             <f:select />
         </f:entry>
         <f:entry title="${%SSH Credentials}" field="credentialsId">

--- a/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate/help-floatingIpPoolId.html
+++ b/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate/help-floatingIpPoolId.html
@@ -1,0 +1,3 @@
+<div>
+  Floating IP Pool to use if attaching a floating IP to this instance.
+</div>

--- a/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate/help-networkId.html
+++ b/openstack-cloud/src/main/resources/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate/help-networkId.html
@@ -1,0 +1,3 @@
+<div>
+  The network to connect the instance to.
+</div>

--- a/openstack-cloud/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudInsideJenkinsLiveTest.java
+++ b/openstack-cloud/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudInsideJenkinsLiveTest.java
@@ -26,7 +26,7 @@ public class JCloudsCloudInsideJenkinsLiveTest extends HudsonTestCase {
 
         // TODO: this may need to vary per test
         cloud = new JCloudsCloud("profile", fixture.getIdentity(), fixture.getCredential(),
-                fixture.getEndpoint(), 1, DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES, 600 * 1000, 600 * 1000, null,
+                fixture.getEndpoint(), 1, DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES, 0, 600 * 1000, 600 * 1000, null,
                 Collections.<JCloudsSlaveTemplate>emptyList(), true);
     }
 

--- a/openstack-cloud/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudLiveTest.java
+++ b/openstack-cloud/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudLiveTest.java
@@ -27,7 +27,7 @@ public class JCloudsCloudLiveTest extends TestCase {
 
         // TODO: this may need to vary per test
         cloud = new JCloudsCloud("profile", fixture.getIdentity(), fixture.getCredential(),
-                fixture.getEndpoint(), 1, DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES, 600 * 1000, 600 * 1000, null,
+                fixture.getEndpoint(), 1, DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES, 0, 600 * 1000, 600 * 1000, null,
                 Collections.<JCloudsSlaveTemplate>emptyList(), true);
     }
 

--- a/openstack-cloud/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudTest.java
+++ b/openstack-cloud/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudTest.java
@@ -53,7 +53,7 @@ public class JCloudsCloudTest {
     public void testConfigRoundtrip() throws Exception {
 
         JCloudsCloud original = new JCloudsCloud("openstack-profile", "identity", "credential", "endPointUrl", 1, DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES,
-                600 * 1000, 600 * 1000, null, Collections.<JCloudsSlaveTemplate>emptyList(), true);
+                0, 600 * 1000, 600 * 1000, null, Collections.<JCloudsSlaveTemplate>emptyList(), true);
 
         j.getInstance().clouds.add(original);
         j.submit(j.createWebClient().goTo("configure").getFormByName("config"));

--- a/openstack-cloud/src/test/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplateTest.java
+++ b/openstack-cloud/src/test/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplateTest.java
@@ -16,13 +16,13 @@ public class JCloudsSlaveTemplateTest extends HudsonTestCase {
         String name = "testSlave";
         JCloudsSlaveTemplate originalTemplate = new JCloudsSlaveTemplate(name, "imageId", "hardwareId",
                 "openstack-slave-type1 openstack-type2", "userData", "1", false, null, null, true, 0,
-                "keyPair", "network1_id,network2_id", "default", null, JCloudsCloud.SlaveType.SSH, null);
+                "keyPair", "network1_id,network2_id", "floatingIPPool1_name", "default", null, JCloudsCloud.SlaveType.SSH, null);
 
         List<JCloudsSlaveTemplate> templates = new ArrayList<JCloudsSlaveTemplate>();
         templates.add(originalTemplate);
 
         JCloudsCloud originalCloud = new JCloudsCloud("aws-profile", "identity", "credential", "endPointUrl", 1, DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES,
-                600 * 1000, 600 * 1000, null, templates, true);
+                0, 600 * 1000, 600 * 1000, null, templates, true);
 
         hudson.clouds.add(originalCloud);
         submit(createWebClient().goTo("configure").getFormByName("config"));


### PR DESCRIPTION
In my environment I ran into two problems with the latest version of the plugin. The first being the inability of jclouds to create and assign a floating IP without specifying a floating ip pool. This occurred where there were no existing IPs available in the pool. The second was Jenkins not being able to launch the node via SSH due to a variable delay in a instance with a floating IP becoming accessible over SSH. This pull request contains my changes to get the plugin working and should be useful to others.

- Adds support for selecting a floating IP pool as part of the instance
  template. The Neutron networks available in this list are ones that
  are set to external:router True.

- Introduces a configurable delay before launching SSH slaves. This
  allows the operator to work around slow availability of SSH on the
  slave instance.