### PR TITLE
[FIXED JENKINS-29998] Jobs without label are never scheduled

### DIFF
--- a/openstack-cloud/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlave.java
+++ b/openstack-cloud/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlave.java
@@ -1,5 +1,6 @@
 package jenkins.plugins.openstack.compute;
 
+import static jenkins.plugins.openstack.compute.CloudInstanceDefaults.DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES;
 import hudson.Extension;
 import hudson.model.TaskListener;
 import hudson.model.Descriptor;
@@ -17,8 +18,6 @@ import java.util.logging.Logger;
 import org.jclouds.compute.ComputeService;
 import org.jclouds.compute.domain.NodeMetadata;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import static jenkins.plugins.openstack.compute.CloudInstanceDefaults.DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES;
 
 /**
  * Jenkins Slave node - managed by JClouds.
@@ -70,7 +69,7 @@ public class JCloudsSlave extends AbstractCloudSlave {
     public JCloudsSlave(final String cloudName, final String fsRoot, NodeMetadata metadata, final String labelString,
             final String numExecutors, final boolean stopOnTerminate, final int overrideRetentionTime,
             String jvmOptions, final String credentialsId, final JCloudsCloud.SlaveType slaveType) throws IOException, Descriptor.FormException {
-        this(cloudName, metadata.getName(), fsRoot, numExecutors, Mode.EXCLUSIVE, labelString,
+        this(cloudName, metadata.getName(), fsRoot, numExecutors, Mode.NORMAL, labelString,
                 new JCloudsLauncher(), new JCloudsRetentionStrategy(), Collections.<NodeProperty<?>>emptyList(),
                 stopOnTerminate, overrideRetentionTime, jvmOptions, credentialsId, slaveType);
         this.nodeMetaData = metadata;


### PR DESCRIPTION
... so does most of matrix combinations.

As these jobs have no label at all, they are never assigned on `EXCLUSIVE` slaves.

[JENKINS-29998](https://issues.jenkins-ci.org/browse/JENKINS-29998)