### PR TITLE
Added capability to set the name of floating IP pool to use

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsCloud.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsCloud.java
@@ -10,7 +10,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.annotation.CheckForNull;
@@ -62,6 +61,7 @@ public class JCloudsCloud extends Cloud {
     public final String zone;
     // Ask for a floating IP to be associated for every machine provisioned
     private final boolean floatingIps;
+    private final String floatingIpPool;
 
     public enum SlaveType {SSH, JNLP}
 
@@ -85,7 +85,7 @@ public class JCloudsCloud extends Cloud {
     @DataBoundConstructor @Restricted(DoNotUse.class)
     public JCloudsCloud(final String profile, final String identity, final String credential, final String endPointUrl, final int instanceCap,
                         final int retentionTime, final int startTimeout, final String zone, final List<JCloudsSlaveTemplate> templates,
-                        final boolean floatingIps
+                        final boolean floatingIps, final String floatingIpPool
     ) {
         super(Util.fixEmptyAndTrim(profile));
         this.profile = Util.fixEmptyAndTrim(profile);
@@ -98,6 +98,7 @@ public class JCloudsCloud extends Cloud {
         this.templates = Collections.unmodifiableList(Objects.firstNonNull(templates, Collections.<JCloudsSlaveTemplate> emptyList()));
         this.zone = Util.fixEmptyAndTrim(zone);
         this.floatingIps = floatingIps;
+        this.floatingIpPool = Util.fixEmptyAndTrim(floatingIpPool);
     }
 
     /**
@@ -110,6 +111,10 @@ public class JCloudsCloud extends Cloud {
 
     public boolean isFloatingIps() {
         return floatingIps;
+    }
+
+    public String getFloatingIpPool() {
+        return floatingIpPool;
     }
 
     @Restricted(NoExternalUse.class)

--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
@@ -241,7 +241,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate> {
 
         if (cloud.isFloatingIps()) {
             LOGGER.fine("Assiging floating IP to " + nodeName);
-            openstack.assignFloatingIp(server);
+            openstack.assignFloatingIp(server, cloud.getFloatingIpPool());
             // Make sure address information is refreshed
             return openstack.updateInfo(server);
         }

--- a/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
@@ -229,11 +229,10 @@ public class Openstack {
         }
     }
 
-    public @Nonnull FloatingIP assignFloatingIp(@Nonnull Server server) {
+    public @Nonnull FloatingIP assignFloatingIp(@Nonnull Server server, String pool) {
         debug("Allocating floating IP for " + server.getName());
         ComputeFloatingIPService fips = client.compute().floatingIps();
-        String publicPool = null;
-        FloatingIP ip = fips.allocateIP(publicPool);
+        FloatingIP ip = fips.allocateIP(pool);
         debug("Floating IP allocated " + ip.getFloatingIpAddress());
         try {
             debug("Assigning floating IP to " + server.getName());

--- a/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/config.jelly
+++ b/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/config.jelly
@@ -26,6 +26,9 @@
         <f:entry title="Associate floating IP" field="floatingIps">
             <f:checkbox/>
         </f:entry>
+        <f:entry title="Floating IP Pool" field="floatingIpPool">
+            <f:textbox default=""/>
+        </f:entry>
         <f:entry title="Default Instance Startup Timeout" field="startTimeout">
             <f:textbox default="600000"/>
         </f:entry>

--- a/src/test/java/jenkins/plugins/openstack/PluginTestRule.java
+++ b/src/test/java/jenkins/plugins/openstack/PluginTestRule.java
@@ -211,7 +211,7 @@ public final class PluginTestRule extends JenkinsRule {
         private final transient Openstack os = mock(Openstack.class, RETURNS_SMART_NULLS);
 
         public MockJCloudsCloud(JCloudsSlaveTemplate... templates) {
-            super("openstack", "identity", "credential", "endPointUrl", 1, CloudInstanceDefaults.DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES, 600 * 1000, null, Arrays.asList(templates), true);
+            super("openstack", "identity", "credential", "endPointUrl", 1, CloudInstanceDefaults.DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES, 600 * 1000, null, Arrays.asList(templates), true, "public");
         }
 
         @Override

--- a/src/test/java/jenkins/plugins/openstack/compute/JCloudsBuildWrapperTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/JCloudsBuildWrapperTest.java
@@ -57,7 +57,7 @@ public class JCloudsBuildWrapperTest {
         j.buildAndAssertSuccess(p);
 
         verify(os, times(3)).bootAndWaitActive(any(ServerCreateBuilder.class), any(Integer.class));
-        verify(os, times(3)).assignFloatingIp(any(Server.class));
+        verify(os, times(3)).assignFloatingIp(any(Server.class), eq("public"));
         verify(os, times(3)).updateInfo(any(Server.class));
         verify(os, times(3)).destroyServer(any(Server.class));
         verifyNoMoreInteractions(os);
@@ -88,7 +88,7 @@ public class JCloudsBuildWrapperTest {
 
         verify(os, times(6)).bootAndWaitActive(any(ServerCreateBuilder.class), any(Integer.class)); // 5 retries on exception
         verify(os, times(1)).updateInfo(any(Server.class));
-        verify(os, times(1)).assignFloatingIp(any(Server.class));
+        verify(os, times(1)).assignFloatingIp(any(Server.class), eq("public"));
         verify(os, times(1)).destroyServer(any(Server.class)); // Cleanup after the successful attempt
         verifyNoMoreInteractions(os);
     }

--- a/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudTest.java
@@ -99,7 +99,7 @@ public class JCloudsCloudTest {
     @Test
     public void testConfigRoundtrip() throws Exception {
         JCloudsCloud original = new JCloudsCloud(
-                "openstack", "identity", "credential", "endPointUrl", 1, CloudInstanceDefaults.DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES, 600 * 1000, null, Collections.<JCloudsSlaveTemplate>emptyList(), true
+                "openstack", "identity", "credential", "endPointUrl", 1, CloudInstanceDefaults.DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES, 600 * 1000, null, Collections.<JCloudsSlaveTemplate>emptyList(), true, "public"
         );
         j.jenkins.clouds.add(original);
 
@@ -205,6 +205,7 @@ public class JCloudsCloudTest {
         assertEquals("http://my.openstack:5000/v2.0", cloud.endPointUrl);
         assertEquals("tenant:user", cloud.identity);
         assertEquals(true, cloud.isFloatingIps());
+        assertEquals("public", cloud.getFloatingIpPool());
 
         JCloudsSlaveTemplate template = cloud.getTemplate("ath-integration-test");
         assertEquals("16", template.hardwareId);

--- a/src/test/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplateTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplateTest.java
@@ -31,7 +31,7 @@ public class JCloudsSlaveTemplateTest {
         templates.add(originalTemplate);
 
         JCloudsCloud originalCloud = new JCloudsCloud(CLOUD_NAME, "identity", "credential", "endPointUrl", 1, DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES,
-                600 * 1000, null, templates, true);
+                600 * 1000, null, templates, true, "public");
 
         j.jenkins.clouds.add(originalCloud);
         j.submit(j.createWebClient().goTo("configure").getFormByName("config"));

--- a/src/test/resources/jenkins/plugins/openstack/compute/JCloudsCloudTest/globalConfigMigrationFromV1/config.xml
+++ b/src/test/resources/jenkins/plugins/openstack/compute/JCloudsCloudTest/globalConfigMigrationFromV1/config.xml
@@ -46,6 +46,7 @@
       <scriptTimeout>600000</scriptTimeout>
       <startTimeout>600000</startTimeout>
       <floatingIps>true</floatingIps>
+      <floatingIpPool>public</floatingIpPool>
     </jenkins.plugins.openstack.compute.JCloudsCloud>
   </clouds>
   <quietPeriod>5</quietPeriod>


### PR DESCRIPTION
# Allow Specifying Name for Floating IP Pool

When the current plugin requests to associate a floating IP with an instance then the IP is always taken from the default public pool as the pool name is hardcoded to null. 

This change allows a jenkins admin to specify a named floating ip pool to use when associating floating IPs. If the field in the jenkins UI is left blank then the behaviour will be as is.