### PR TITLE
Ignore destroying machine if not found

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
@@ -273,6 +273,13 @@ public class Openstack {
             }
 
             res = client.compute().servers().delete(server.getId());
+
+            // Ignore if server is not found. It may have already been deleted.
+            if (res.getCode() == 404) {
+                debug("Machine " + deleted.getName() + " not found.");
+                break;
+            }
+
             throwIfFailed(res);
         }
 


### PR DESCRIPTION
Fixes issue where if the destroyServer() command is called twice for the
same machine the 2nd attempt will throw 404 which we can ignore instead
of failing the job.

Jira: JENKINS-34899
Signed-off-by: Thanh Ha <zxiiro@linux.com>