### PR TITLE
Prefix image lookup with eq: to prevent issues with names containing colons

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
@@ -169,7 +169,7 @@ public class Openstack {
 
     public @CheckForNull String getImageIdFor(String name) {
         Map<String, String> query = new HashMap<>(2);
-        query.put("name", name);
+        query.put("name", "eq:" + name); // prefix with eq: to prevent issues with names containing colons
         query.put("status", "active");
 
         List<? extends Image> images = client.images().listAll(query);


### PR DESCRIPTION
Upgraded to Glance 12.0.0 and started getting 500 error response codes from the Glance API. Found errors like these in the log:

InvalidFilterOperatorValue: Unable to filter by unknown operator 'Debian 8 2016-04-17T22'.

Seems to be because my image names have colon characters in them, and Glance is interpreting the colon as a separator between operators. This pull request prefixes the 'eq:' operator to the image name in the API request which fixes the problem. 

Thanks
