### PR TITLE
Issue #105: Only administrator is able to provision a node on /computer/ page

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsCloud.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsCloud.java
@@ -25,6 +25,7 @@ import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 
 import hudson.Functions;
+import hudson.model.Item;
 import hudson.plugins.sshslaves.SSHLauncher;
 import hudson.slaves.ComputerLauncher;
 import hudson.slaves.JNLPLauncher;
@@ -389,7 +390,7 @@ public class JCloudsCloud extends Cloud implements SlaveOptions.Holder {
     @Restricted(DoNotUse.class)
     public void doProvision(StaplerRequest req, StaplerResponse rsp, @QueryParameter String name) throws ServletException, IOException,
             Descriptor.FormException {
-        checkPermission(PROVISION);
+        checkPermission(Item.BUILD);
         if (name == null) {
             sendError("The slave template name query parameter is missing", req, rsp);
             return;

--- a/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/computerSet.jelly
+++ b/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/computerSet.jelly
@@ -1,7 +1,8 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
          xmlns:f="/lib/form">
-    <j:if test="${it.hasPermission(it.PROVISION)}">
+    <j:getStatic var="buildPermission" className="hudson.model.Item" field="BUILD"/>
+    <j:if test="${it.hasPermission(buildPermission)}">
 
         <tr>
             <td/>


### PR DESCRIPTION
As discussed with Oliver, the issue is in core. 
As a temporary solution before the core is fixed, the node provisioning on /computer/ page is set to be allowed to user which has job BUILD permission. 