### PR TITLE
Remove requirement for a floating ip

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/SlaveOptionsDescriptor.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/SlaveOptionsDescriptor.java
@@ -194,10 +194,11 @@ public final class SlaveOptionsDescriptor extends hudson.model.Descriptor<SlaveO
     ) {
         if (Util.fixEmpty(value) == null) {
             String d = getDefault(def, opts().getFloatingIpPool());
-            if (d != null) return FormValidation.ok(def(d));
-            return REQUIRED;
+            if (d != null) {
+                return FormValidation.ok(def(d));
+            }
+            return OK;
         }
-        return OK;
     }
 
     @Restricted(DoNotUse.class)


### PR DESCRIPTION
Certain clouds work just fine without them, so don't make them required.
