### PR TITLE
Allow for providing X az(s) and picking one

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
@@ -226,6 +226,15 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 
         String az = opts.getAvailabilityZone();
         if (!Strings.isNullOrEmpty(az)) {
+            // Allow for one of X azs to be given, and
+            // picking one at random from that set.
+            String[] azs = az.split(",");
+            if (azs.length > 1) {
+                az = azs[new Random().nextInt(azs.length)];
+            }
+            else {
+                az = azs[0];
+            }
             LOGGER.fine("Setting availabilityZone to " + az);
             builder.availabilityZone(az);
         }


### PR DESCRIPTION
It can be quite useful to scatter instances across
a set of az(s) for partitioning reasons (and more)
so make it possible to do that easily.