### PR TITLE
Support to Auth V3 with domain name.  project:userName:domain for V3 

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
@@ -99,7 +99,7 @@ public class Openstack {
         String tenant = id.length > 0 ? id[0] : "";
         String username = id.length > 1 ? id[1] : "";
         String domain = id.length > 2 ? id[2] : "";
-        if (domain=="") {
+        if (domain.equals("")) {
             //If domain is empty it is assumed that is being used API V2
             client = OSFactory.builder().endpoint(endPointUrl)
                     .credentials(username, credential.getPlainText())

--- a/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
@@ -57,6 +57,7 @@ import org.openstack4j.api.OSClient;
 import org.openstack4j.api.compute.ComputeFloatingIPService;
 import org.openstack4j.api.exceptions.ResponseException;
 import org.openstack4j.model.common.BasicResource;
+import org.openstack4j.model.common.Identifier;
 import org.openstack4j.model.compute.ActionResponse;
 import org.openstack4j.model.compute.Address;
 import org.openstack4j.model.compute.Fault;
@@ -94,15 +95,30 @@ public class Openstack {
 
     public Openstack(@Nonnull String endPointUrl, @Nonnull String identity, @Nonnull Secret credential, @CheckForNull String region) {
         // TODO refactor to split tenant:username everywhere including UI
-        String[] id = identity.split(":", 2);
+        String[] id = identity.split(":",3);
         String tenant = id.length > 0 ? id[0] : "";
         String username = id.length > 1 ? id[1] : "";
-        client = OSFactory.builder().endpoint(endPointUrl)
-                .credentials(username, credential.getPlainText())
-                .tenantName(tenant)
-                .authenticate()
-                .useRegion(region)
-        ;
+        String domain = id.length > 2 ? id[2] : "";
+        if (domain=="") {
+            //If domain is empty it is assumed that is being used API V2
+            client = OSFactory.builder().endpoint(endPointUrl)
+                    .credentials(username, credential.getPlainText())
+                    .tenantName(tenant)
+                    .authenticate()
+                    .useRegion(region);
+        } else {
+             //If not it is assumed that it is being used API V3
+
+                Identifier iDomain = Identifier.byName(domain);
+                Identifier project = Identifier.byName(tenant);
+                client = OSFactory.builderV3().endpoint(endPointUrl)
+                        .credentials(username, credential.getPlainText(), iDomain)
+                        .scopeToProject(project, iDomain)
+                        .authenticate()
+                        .useRegion(region)
+                ;
+        }
+
         debug("Openstack client created for " + endPointUrl);
     }
 


### PR DESCRIPTION
The support to domain name V3 Auth is as simple as split the domain name as another part of the identity string. 
Using project:userName:DOMAIN and is compatible with project:username