### PR TITLE
Ensure compatibility with different versions of c-f-p

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,10 +21,10 @@
         <surefire.useFile>false</surefire.useFile>
         <findbugs.excludeFilterFile>src/findbugs-exclude.xml</findbugs.excludeFilterFile>
 
-
         <guava.version>17.0</guava.version> <!-- version compatible with openstack4j -->
         <jsr305.version>1.3.9</jsr305.version>
         <openstack4j.version>2.0.9</openstack4j.version>
+        <config-file-provider.version>2.7.5</config-file-provider.version>
     </properties>
 
     <developers>
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>config-file-provider</artifactId>
-            <version>2.7.5</version>
+            <version>${config-file-provider.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/jenkins/plugins/openstack/compute/UserDataConfig.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/UserDataConfig.java
@@ -1,18 +1,24 @@
 package jenkins.plugins.openstack.compute;
 
-
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import jenkins.model.Jenkins;
 import org.jenkinsci.lib.configprovider.AbstractConfigProviderImpl;
+import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
 import org.kohsuke.stapler.DataBoundConstructor;
-
 
 public class UserDataConfig extends Config {
 
     @DataBoundConstructor
     public UserDataConfig(String id, String name, String comment, String content) {
         super(id, name, comment, content);
+    }
+
+    @Override
+    public ConfigProvider getDescriptor() {
+        return Jenkins.getActiveInstance().getDescriptorByType(UserDataConfigProvider.class);
     }
 
     @Extension(ordinal = 70)
@@ -32,5 +38,16 @@ public class UserDataConfig extends Config {
             return "OpenStack User Data";
         }
 
+        @NonNull
+        @Override
+        public UserDataConfig newConfig(@NonNull String id) {
+            return new UserDataConfig(id, "UserData", "", "");
+        }
+
+        // used for migration only
+        @Override
+        public UserDataConfig convert(Config config) {
+            return new UserDataConfig(config.id, config.name, config.comment, config.content);
+        }
     }
 }

--- a/src/main/java/jenkins/plugins/openstack/compute/UserDataConfig.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/UserDataConfig.java
@@ -39,13 +39,13 @@ public class UserDataConfig extends Config {
         }
 
         @NonNull
-        @Override
+        // @Override c-f-p 2.15+
         public UserDataConfig newConfig(@NonNull String id) {
             return new UserDataConfig(id, "UserData", "", "");
         }
 
         // used for migration only
-        @Override
+        // @Override c-f-p 2.15+
         public UserDataConfig convert(Config config) {
             return new UserDataConfig(config.id, config.name, config.comment, config.content);
         }

--- a/src/main/resources/jenkins/plugins/openstack/compute/UserDataConfig/edit-config.jelly
+++ b/src/main/resources/jenkins/plugins/openstack/compute/UserDataConfig/edit-config.jelly
@@ -1,0 +1,32 @@
+<!--
+The MIT License
+Copyright (c) 2016, Dominik Bartholdi
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+					<j:set var="descriptor" value="${config.descriptor}"/>
+					<st:include page="id-name-and-comment"  class="${descriptor.clazz}"/>
+					<f:entry title="${%Content}">
+						<f:textarea id="config.content" name="config.content" value="${config.content}" /> 
+					</f:entry>
+					
+</j:jelly>

--- a/src/main/resources/jenkins/plugins/openstack/compute/UserDataConfig/show-config.jelly
+++ b/src/main/resources/jenkins/plugins/openstack/compute/UserDataConfig/show-config.jelly
@@ -1,0 +1,37 @@
+<!--
+The MIT License
+Copyright (c) 2016, Dominik Bartholdi
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+	<f:entry title="${%ID}">
+		<f:textbox readonly="readonly" name="config.id" value="${config.id}" />
+	</f:entry>
+	<f:entry title="${%Name}">
+		<f:textbox readonly="readonly" name="config.name" value="${config.name}" />
+	</f:entry>
+	<f:entry title="${%Comment}">
+		<f:textbox readonly="readonly" name="config.comment" value="${config.comment}" />
+	</f:entry>
+	<f:entry title="${%Content}">
+		<f:textarea readonly="readonly" id="config.content" name="config.content" value="${config.content}" />
+	</f:entry>
+
+</j:jelly>

--- a/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudTest.java
@@ -274,7 +274,7 @@ public class JCloudsCloudTest {
 
         configfiles = wc.goTo("configfiles");
         HtmlPage newOne = configfiles.getAnchorByText("Add a new Config").click();
-        HtmlForm form = newOne.getFormByName("addConfig");
+        HtmlForm form = newOne.getForms().get(1);
         form.getOneHtmlElementByAttribute("input", "value", "jenkins.plugins.openstack.compute.UserDataConfig").click();
         HtmlPage newForm = j.submit(form);
         j.submit(newForm.getForms().get(1));


### PR DESCRIPTION
This will work with c-f-p before 2.14 and after 2.15.4 (provided https://github.com/jenkinsci/config-file-provider-plugin/pull/29 gets released). The old API still exists and delegate to global store where the files are after migration.

@imod, please review this and https://github.com/jenkinsci/config-file-provider-plugin/pull/29. I have verified that this is compatible with both new and old releases of c-f-p.