### PR TITLE
JENKINS-35347: Add support for V3 auth.

### DIFF
--- a/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/help-identity.html
+++ b/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/help-identity.html
@@ -1,3 +1,8 @@
 <div>
-  Identity of the user to start the machine (<tt>TENANT_NAME:USER_NAME</tt>).
+  The user identity used by Jenkins when communicating with OpenStack.
+  The format required depends on the authentication method used by the OpenStack system.
+  <ul>
+  <li>For v2 authentication use syntax <tt>TENANT_NAME:USER_NAME</tt></li>
+  <li>For v3 authentication use syntax <tt>PROJECT_NAME:USER_NAME:DOMAIN_NAME</tt></li>
+  </ul>
 </div>


### PR DESCRIPTION
If user provides identity of the form "tenant:username" then V2 is used as before.
If user provides identity of the form "project:username:domain" then V3 is used.

Note: This is (heavily!) based on https://github.com/jenkinsci/openstack-cloud-plugin/pull/124 by FROSADO.
I've added help-text to the configuration UI, and I've changed the code layout to minimize code duplication and number of lines changed, but functionally it's as PR124.
I've carried out basic "test connection" tests against our (in-house) old v2-auth OpenStack system and our new v3-auth OpenStack system and this new code is able to connect to both and e.g. list images to populate drop-down lists.