### PR TITLE
Get JNLP working with security and Jenkins 2.27+

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsLauncher.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsLauncher.java
@@ -4,6 +4,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.TaskListener;
 import hudson.model.Descriptor;
 import hudson.slaves.ComputerLauncher;
+import hudson.slaves.DelegatingComputerLauncher;
+import hudson.slaves.JNLPLauncher;
 import hudson.slaves.SlaveComputer;
 
 import javax.annotation.Nonnull;
@@ -14,14 +16,12 @@ import java.util.logging.Logger;
 /*
  * This class as designed, is not supposed to be shared among multiple computers.
  */
-public class JCloudsLauncher extends ComputerLauncher {
+public class JCloudsLauncher extends DelegatingComputerLauncher {
 
     private static final Logger LOGGER = Logger.getLogger(JCloudsLauncher.class.getName());
 
-    /*package for testing*/ /*almost final*/ @Nonnull ComputerLauncher launcher;
-
     public JCloudsLauncher(@Nonnull ComputerLauncher launcher) {
-        this.launcher = launcher;
+        super(launcher);
     }
 
     @Override
@@ -61,6 +61,7 @@ public class JCloudsLauncher extends ComputerLauncher {
         //return null;
 
         final JCloudsSlave slave = (JCloudsSlave) computer.getNode();
+        if ( slave==null ) return launcher = new JNLPLauncher();
         return launcher = slave.getSlaveType().createLauncher(slave);
     }
 }

--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
@@ -2,7 +2,6 @@ package jenkins.plugins.openstack.compute;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -42,6 +41,7 @@ import hudson.model.labels.LabelAtom;
 import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
 import jenkins.plugins.openstack.compute.internal.Openstack;
+import jenkins.slaves.JnlpSlaveAgentProtocol;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -272,6 +272,12 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
             vars.put("SLAVE_JAR_URL", rootUrl + "jnlpJars/slave.jar");
             vars.put("SLAVE_JNLP_URL", rootUrl + "computer/" + serverName + "/slave-agent.jnlp");
             vars.put("SLAVE_LABELS", labelString);
+            String slaveSecret = JnlpSlaveAgentProtocol.SLAVE_SECRET.mac(serverName);
+            if (slaveSecret != null) {
+                vars.put("SLAVE_JNLP_SECRET", slaveSecret);
+            }
+            vars.put("SLAVE_JENKINS_HOME", Util.fixNull(opts.getFsRoot()));
+            vars.put("SLAVE_JVM_OPTIONS", Util.fixNull(opts.getJvmOptions()));
             String content = Util.replaceMacro(userDataText, vars);
             LOGGER.fine("Sending user-data:\n" + content);
             builder.userData(Base64.encode(content.getBytes(Charsets.UTF_8)));

--- a/src/main/resources/jenkins/plugins/openstack/compute/SlaveOptions/help-userDataId.jelly
+++ b/src/main/resources/jenkins/plugins/openstack/compute/SlaveOptions/help-userDataId.jelly
@@ -1,6 +1,44 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
   <div>
-    You can specify userdata via <a target="_blank" href="${app.rootUrl}configfiles/">Jenkins -> Manage Jenkins -> Managed Files -> Add New Config (OpenStack User Data)</a>.
+    Selects which (if any) user data is sent to the cloud-init process when the instance first boots up.
+    The cloud-init process typically auto-detects the format/syntax of the script from the first line.
+    <p>
+    You can define userdata via <a target="_blank" href="${app.rootUrl}configfiles/">Jenkins -> Manage Jenkins -> Managed Files -> Add New Config (OpenStack User Data)</a>.
+    </p>
+    <p>
+    Before the userdata is sent to the OpenStack instance, the following values are injected and can be referenced within the userdata using $${VARIABLE_NAME} syntax:
+    <ul>
+      <li><tt>JENKINS_URL</tt>: The URL of the Jenkins instance.</li>
+      <li><tt>SLAVE_JAR_URL</tt>: The URL of the JNLP executable slave.jar.</li>
+      <li><tt>SLAVE_JENKINS_HOME</tt>: The &quot;Remote FS Root&quot;.</li>
+      <li><tt>SLAVE_JNLP_SECRET</tt>: The JNLP &quot;secret&quot; key.</li>
+      <li><tt>SLAVE_JNLP_URL</tt>: The endpoint URL for the JNLP connection.</li>
+      <li><tt>SLAVE_JVM_OPTIONS</tt>: The &quot;Custom JVM Options&quot;.</li>
+      <li><tt>SLAVE_LABELS</tt>: Labels of this Jenkins slave node.</li>
+    </ul>
+    </p>
+    <p>
+    For example, a unix-based JNLP slave could use a script such as
+    <blockquote>
+      <tt>
+      #!/bin/sh<br/>
+      mkdir -p &quot;$${SLAVE_JENKINS_HOME}&quot;<br/>
+      wget &quot;$${SLAVE_JAR_URL}&quot; -O &quot;$${SLAVE_JENKINS_HOME}/slave.jar&quot;<br/>
+      cd &quot;$${SLAVE_JENKINS_HOME}&quot;<br/>
+      java $${SLAVE_JVM_OPTIONS} -jar &quot;$${SLAVE_JENKINS_HOME}/slave.jar&quot; -jnlpUrl &quot;$${SLAVE_JNLP_URL}&quot; -secret &quot;$${SLAVE_JNLP_SECRET}&quot;
+      </tt>
+    </blockquote>
+    whereas a Windows-based JNLP slave could use a script such as
+    <blockquote>
+      <tt>
+        #ps1<br/>
+        mkdir -Force &quot;$${SLAVE_JENKINS_HOME}&quot;<br/>
+        (new-object System.Net.WebClient).DownloadFile(&apos;$${SLAVE_JAR_URL}&apos;,&apos;$${SLAVE_JENKINS_HOME}\slave.jar&apos;)<br/>
+        cd &quot;$${SLAVE_JENKINS_HOME}&quot;<br/>
+        java $${SLAVE_JVM_OPTIONS} -jar &quot;slave.jar&quot; -jnlpUrl &quot;$${SLAVE_JNLP_URL}&quot; -secret &quot;$${SLAVE_JNLP_SECRET}&quot;
+      </tt>
+    </blockquote>
+    </p>
   </div>
 </j:jelly>

--- a/src/test/java/jenkins/plugins/openstack/compute/ProvisioningTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/ProvisioningTest.java
@@ -254,7 +254,7 @@ public class ProvisioningTest {
 
         JCloudsSlave slave = j.provision(cloud, "label");
 
-        SSHLauncher launcher = (SSHLauncher) ((JCloudsLauncher) slave.getLauncher()).launcher;
+        SSHLauncher launcher = (SSHLauncher) ((JCloudsLauncher) slave.getLauncher()).getLauncher();
         assertEquals(slave.getPublicAddress(), launcher.getHost());
         assertEquals(expected.getCredentialsId(), launcher.getCredentialsId());
         assertEquals(expected.getJvmOptions(), launcher.getJvmOptions());


### PR DESCRIPTION
Jenkins 2.27 introduced a change to JNLP connections which broke the vSphere cloud plugin - see JENKINS-39232 for details.
The OpenStack plugin has the same problem, and the same fix applies: JCloudsLauncher needs to extend DelegatingComputerLauncher instead of ComputerLauncher; that way the Jenkins core can "see through" our launcher to the underlying JNLPLauncher (otherwise the core will refuse the JNLP connection).
This then required a corresponding change to ProvisioningTest.

For JNLP to work with security enabled (i.e. where anonymous users cannot connect a slave) requires us to pass the "secret" key to the slave.jar, so I've exposed additional variables to the User Data functionality in JCloudsSlaveTemplate.

Lastly, I've added lots of text to the online help for the User Data field so that anyone needing to do JNLP now has a couple of examples that they can just copy & paste.