### PR TITLE
Add support for volumeSnapshots

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/OsAuthDescriptor.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/OsAuthDescriptor.java
@@ -1,0 +1,127 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.plugins.openstack.compute;
+
+import com.google.common.base.Joiner;
+import hudson.Util;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import hudson.util.ListBoxModel;
+import hudson.util.ReflectionUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.springframework.util.StringUtils;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Helper descriptor abstraction for classes with AJAX methods depending on OS auth parameters.
+ *
+ * @author ogondza.
+ */
+@Restricted(NoExternalUse.class)
+public abstract class OsAuthDescriptor<DESCRIBABLE extends Describable<DESCRIBABLE>> extends Descriptor<DESCRIBABLE> {
+
+    public OsAuthDescriptor() {
+        super();
+    }
+
+    public OsAuthDescriptor(Class<DESCRIBABLE> describableClass) {
+        super(describableClass);
+    }
+
+    /**
+     * Get relative <tt>fillDependsOn</tt> offsets to apply.
+     */
+    public abstract List<String> getAuthFieldsOffsets();
+
+    protected static boolean hasValue(ListBoxModel m, String value) {
+        for( final ListBoxModel.Option o : m) {
+            if ( Objects.equals(value, o.value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Add dependencies on credentials for methods annotated with {@link InjectOsAuth} annotation.
+     */
+    @Override
+    public final void calcFillSettings(String field, Map<String, Object> attributes) {
+        super.calcFillSettings(field, attributes);
+
+        List<String> deps = new ArrayList<>();
+        String fillDependsOn = (String) attributes.get("fillDependsOn");
+        if (fillDependsOn != null) {
+            deps.addAll(Arrays.asList(fillDependsOn.split(" ")));
+        }
+
+        String capitalizedFieldName = StringUtils.capitalize(field);
+        String methodName = "doFill" + capitalizedFieldName + "Items";
+        Method method = ReflectionUtils.getPublicMethodNamed(getClass(), methodName);
+
+        // Replace direct reference to references to possible relative paths
+        if (method.getAnnotation(InjectOsAuth.class) != null) {
+            for (String attr: Arrays.asList("endPointUrl", "identity", "credential", "zone")) {
+                deps.remove(attr);
+                for (String offset : getAuthFieldsOffsets()) {
+                    deps.add(offset + "/" + attr);
+                }
+            }
+        }
+
+        if (!deps.isEmpty()) {
+            attributes.put("fillDependsOn", Joiner.on(' ').join(deps));
+        }
+    }
+
+    protected static boolean haveAuthDetails(String endPointUrl, String identity, String credential, String zone) {
+        return Util.fixEmpty(endPointUrl)!=null && Util.fixEmpty(identity)!=null && Util.fixEmpty(credential)!=null;
+    }
+
+    public static String getDefault(String d1, Object d2) {
+        d1 = Util.fixEmpty(d1);
+        if (d1 != null) return d1;
+        if (d2 != null) return Util.fixEmpty(String.valueOf(d2));
+        return null;
+    }
+
+    /**
+     * Method annotation to denote AJAX method accepts OS auth parameters.
+     */
+    @Retention(RUNTIME)
+    @Target({METHOD})
+    public @interface InjectOsAuth {}
+}

--- a/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
@@ -34,7 +34,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Random;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -48,6 +47,7 @@ import javax.annotation.concurrent.ThreadSafe;
 import com.google.common.base.Objects;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.TreeMultimap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.ExtensionList;
@@ -74,11 +74,15 @@ import org.openstack4j.model.compute.FloatingIP;
 import org.openstack4j.model.compute.Keypair;
 import org.openstack4j.model.compute.Server;
 import org.openstack4j.model.compute.builder.ServerCreateBuilder;
+import org.openstack4j.model.compute.ext.AvailabilityZone;
 import org.openstack4j.model.identity.v2.Access;
 import org.openstack4j.model.identity.v3.Token;
 import org.openstack4j.model.image.Image;
 import org.openstack4j.model.network.NetFloatingIP;
 import org.openstack4j.model.network.Network;
+import org.openstack4j.model.storage.block.Volume;
+import org.openstack4j.model.storage.block.Volume.Status;
+import org.openstack4j.model.storage.block.VolumeSnapshot;
 import org.openstack4j.openstack.OSFactory;
 
 import hudson.util.Secret;
@@ -161,17 +165,75 @@ public class Openstack {
         return nets;
     }
 
-    public @Nonnull Collection<Image> getSortedImages() {
-        List<? extends Image> images = clientProvider.get().images().listAll();
-        TreeSet<Image> set = new TreeSet<>(RESOURCE_COMPARATOR); // Eliminate duplicate names
-        set.addAll(images);
-        return set;
-    }
-
     private static final Comparator<BasicResource> RESOURCE_COMPARATOR = new Comparator<BasicResource>() {
         @Override
         public int compare(BasicResource o1, BasicResource o2) {
             return ObjectUtils.compare(o1.getName(), o2.getName());
+        }
+    };
+
+    /**
+     * Finds all {@link Image}s.
+     * 
+     * @return A Map of collections of images, indexed by name (or id if the
+     *         image has no name) in ascending order and, in the event of
+     *         name-collisions, the images for a given name are sorted by
+     *         creation date.
+     */
+    public @Nonnull Map<String, Collection<Image>> getImages() {
+        final List<? extends Image> list = clientProvider.get().images().listAll();
+        final TreeMultimap<String, Image> set = TreeMultimap.create(String.CASE_INSENSITIVE_ORDER, IMAGE_DATE_COMPARATOR);
+        for (Image o : list) {
+            final String name = Util.fixNull(o.getName());
+            final String nameOrId = name.isEmpty() ? o.getId() : name;
+            set.put(nameOrId, o);
+        }
+        return set.asMap();
+    }
+
+    private static final Comparator<Image> IMAGE_DATE_COMPARATOR = new Comparator<Image>() {
+        @Override
+        public int compare(Image o1, Image o2) {
+            int result;
+            result = ObjectUtils.compare(o1.getUpdatedAt(), o2.getUpdatedAt());
+            if (result != 0) return result;
+            result = ObjectUtils.compare(o1.getCreatedAt(), o2.getCreatedAt());
+            if (result != 0) return result;
+            result = ObjectUtils.compare(o1.getId(), o1.getId());
+            return result;
+        }
+    };
+
+    /**
+     * Finds all {@link VolumeSnapshot}s that are {@link Status#AVAILABLE}.
+     * 
+     * @return A Map of collections of {@link VolumeSnapshot}s, indexed by name
+     *         (or id if the volume snapshot has no name) in ascending order
+     *         and, in the event of name-collisions, the volume snapshots for a
+     *         given name are sorted by creation date.
+     */
+    public @Nonnull Map<String, Collection<VolumeSnapshot>> getVolumeSnapshots() {
+        final List<? extends VolumeSnapshot> list = clientProvider.get().blockStorage().snapshots().list();
+        final TreeMultimap<String, VolumeSnapshot> set = TreeMultimap.create(String.CASE_INSENSITIVE_ORDER, VOLUMESNAPSHOT_DATE_COMPARATOR);
+        for (VolumeSnapshot o : list) {
+            if (o.getStatus() != Status.AVAILABLE) {
+                continue;
+            }
+            final String name = Util.fixNull(o.getName());
+            final String nameOrId = name.isEmpty() ? o.getId() : name;
+            set.put(nameOrId, o);
+        }
+        return set.asMap();
+    }
+
+    private static final Comparator<VolumeSnapshot> VOLUMESNAPSHOT_DATE_COMPARATOR = new Comparator<VolumeSnapshot>() {
+        @Override
+        public int compare(VolumeSnapshot o1, VolumeSnapshot o2) {
+            int result;
+            result = ObjectUtils.compare(o1.getCreated(), o2.getCreated());
+            if( result!=0 ) return result;
+            result = ObjectUtils.compare(o1.getId(), o1.getId());
+            return result;
         }
     };
 
@@ -196,6 +258,20 @@ public class Openstack {
         Collections.sort(names);
         return names;
     }
+
+    public @Nonnull
+    List<? extends AvailabilityZone> getAvailabilityZones(){
+        final List<? extends AvailabilityZone> zones = clientProvider.get().compute().zones().list();
+        Collections.sort(zones, AVAILABILITY_ZONES_COMPARATOR);
+        return zones;
+    }
+
+    private static final Comparator<AvailabilityZone> AVAILABILITY_ZONES_COMPARATOR = new Comparator<AvailabilityZone>() {
+        @Override
+        public int compare(AvailabilityZone o1, AvailabilityZone o2) {
+            return ObjectUtils.compare(o1.getZoneName(), o2.getZoneName());
+        }
+    };
 
     /**
      * @return null when user is not authorized to use the endpoint which is a valid use-case.
@@ -242,20 +318,78 @@ public class Openstack {
         return keyPairs;
     }
 
-    public @CheckForNull String getImageIdFor(String name) {
-        Map<String, String> query = new HashMap<>(2);
-        query.put("name", name);
+    /**
+     * Finds the Id(s) of all active {@link Image}s with the given name or ID.
+     * If we have found multiple {@link Image}s then they will be listed in
+     * ascending date order (oldest first).
+     * 
+     * @param nameOrId The {@link Image} name or ID.
+     * @return Zero, one or multiple IDs.
+     */
+    public @Nonnull List<String> getImageIdsFor(String nameOrId) {
+        final Collection<Image> sortedObjects = new TreeSet<>(IMAGE_DATE_COMPARATOR);
+        final Map<String, String> query = new HashMap<>(2);
+        query.put("name", nameOrId);
         query.put("status", "active");
-
-        List<? extends Image> images = clientProvider.get().images().listAll(query);
-        if (images.size() > 0) {
-            // Pick one at random to point out failures ASAP
-            return images.get(new Random().nextInt(images.size())).getId();
+        final List<? extends Image> findByName = clientProvider.get().images().listAll(query);
+        sortedObjects.addAll(findByName);
+        if (nameOrId.matches("[0-9a-f-]{36}")) {
+            final Image findById = clientProvider.get().images().get(nameOrId);
+            if (findById != null && findById.getStatus() == Image.Status.ACTIVE) {
+                sortedObjects.add(findById);
+            }
         }
+        final List<String> ids = new ArrayList<>();
+        for (Image i : sortedObjects) {
+            ids.add(i.getId());
+        }
+        return ids;
+    }
 
-        if (name.matches("[0-1a-f-]{36}")) return name;
+    /**
+     * Finds the Id(s) of all available {@link VolumeSnapshot}s with the given name
+     * or ID. If we have found multiple {@link VolumeSnapshot}s then they will
+     * be listed in ascending date order (oldest first).
+     * 
+     * @param nameOrId The {@link VolumeSnapshot} name or ID.
+     * @return Zero, one or multiple IDs.
+     */
+    public @Nonnull List<String> getVolumeSnapshotIdsFor(String nameOrId) {
+        final Collection<VolumeSnapshot> sortedObjects = new TreeSet<>(VOLUMESNAPSHOT_DATE_COMPARATOR);
+        // OpenStack block-storage/v3 API doesn't allow us to filter by name, so fetch all and search.
+        final Map<String, Collection<VolumeSnapshot>> allVolumeSnapshots = getVolumeSnapshots();
+        final Collection<VolumeSnapshot> findByName = allVolumeSnapshots.get(nameOrId);
+        if (findByName != null) {
+            sortedObjects.addAll(findByName);
+        }
+        if (nameOrId.matches("[0-9a-f-]{36}")) {
+            final VolumeSnapshot findById = clientProvider.get().blockStorage().snapshots().get(nameOrId);
+            if (findById != null && findById.getStatus() == Status.AVAILABLE) {
+                sortedObjects.add(findById);
+            }
+        }
+        final List<String> ids = new ArrayList<>();
+        for (VolumeSnapshot i : sortedObjects) {
+            ids.add(i.getId());
+        }
+        return ids;
+    }
 
-        return null;
+    /**
+     * Sets the name and description of a {@link Volume}. These will be visible
+     * if a user looks at volumes using the OpenStack command-line or WebUI.
+     * 
+     * @param volumeId
+     *            The ID of the volume whose name and description are to be set.
+     * @param newVolumeName
+     *            The new name for the volume.
+     * @param newVolumeDescription
+     *            The new description for the volume.
+     */
+    public void setVolumeNameAndDescription(String volumeId, String newVolumeName, String newVolumeDescription) {
+        final ActionResponse res = clientProvider.get().blockStorage().volumes().update(volumeId, newVolumeName,
+                newVolumeDescription);
+        throwIfFailed(res);
     }
 
     /**

--- a/src/main/java/jenkins/plugins/openstack/compute/slaveopts/BootSource.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/slaveopts/BootSource.java
@@ -1,0 +1,434 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.plugins.openstack.compute.slaveopts;
+
+import hudson.Extension;
+import hudson.RelativePath;
+import hudson.Util;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+import jenkins.plugins.openstack.compute.JCloudsCloud;
+import jenkins.plugins.openstack.compute.OsAuthDescriptor;
+import jenkins.plugins.openstack.compute.internal.Openstack;
+import net.sf.json.JSONObject;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+import org.openstack4j.api.Builders;
+import org.openstack4j.api.exceptions.AuthenticationException;
+import org.openstack4j.api.exceptions.ConnectionException;
+import org.openstack4j.model.compute.BDMDestType;
+import org.openstack4j.model.compute.BDMSourceType;
+import org.openstack4j.model.compute.Server;
+import org.openstack4j.model.compute.builder.BlockDeviceMappingBuilder;
+import org.openstack4j.model.compute.builder.ServerCreateBuilder;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static jenkins.plugins.openstack.compute.SlaveOptionsDescriptor.REQUIRED;
+
+/**
+ * The source media (Image, VolumeSnapshot etc) that the Instance is booted from.
+ */
+@Restricted(NoExternalUse.class)
+public abstract class BootSource extends AbstractDescribableImpl<BootSource> implements Serializable {
+    private static final long serialVersionUID = -838838433829383008L;
+    private static final Logger LOGGER = Logger.getLogger(BootSource.class.getName());
+
+    /**
+     * Configures the given {@link ServerCreateBuilder} to specify that the
+     * newly provisioned server should boot from the specified ID.
+     *
+     * @param builder
+     *            The server specification that is under construction. This will
+     *            be amended.
+     * @param os
+     *            Openstack.
+     * @throws JCloudsCloud.ProvisioningFailedException
+     *             Unable to configure the request. Do not provision.
+     */
+    public void setServerBootSource(@Nonnull ServerCreateBuilder builder, @Nonnull Openstack os)
+            throws JCloudsCloud.ProvisioningFailedException {
+    }
+
+    /**
+     * Called after a server has been provisioned.
+     *
+     * @param server
+     *            The newly-provisioned server.
+     * @param openstack
+     *            Means of communicating with the OpenStack service.
+     * @throws JCloudsCloud.ProvisioningFailedException
+     *             Unable to amend the server so it has to be rolled-back.
+     */
+    public void afterProvisioning(@Nonnull Server server, @Nonnull Openstack openstack)
+            throws JCloudsCloud.ProvisioningFailedException {
+    }
+
+    @Override
+    public BootSourceDescriptor getDescriptor() {
+        return (BootSourceDescriptor) super.getDescriptor();
+    }
+
+    protected String selectIdFromListAndLogProblems(List<String> matchingIds, String name, String pluralOfNameType) {
+        int size = matchingIds.size();
+        final String id;
+        if (size < 1) {
+            LOGGER.info("NO " + pluralOfNameType + " match name '" + name + "'.");
+            id = name;
+        } else if (size == 1) {
+            id = matchingIds.get(0);
+        } else {
+            id = matchingIds.get(size - 1);
+            LOGGER.warning("Ambiguity: " + size + " " + pluralOfNameType + " match name '" + name
+                    + "'. Using the most recent one: " + id);
+        }
+        return id;
+    }
+
+    public abstract static class BootSourceDescriptor extends OsAuthDescriptor<BootSource> {
+        @Override
+        public List<String> getAuthFieldsOffsets() {
+            return Arrays.asList("../..", "../../..");
+        }
+
+        protected ListBoxModel makeListBoxModelOfAllNames(String existingValue, String endPointUrl, String identity,
+                String credential, String zone) {
+            ListBoxModel m = new ListBoxModel();
+            final String valueOrEmpty = Util.fixNull(existingValue);
+            m.add(new ListBoxModel.Option("None specified", "", valueOrEmpty.isEmpty()));
+            try {
+                if (haveAuthDetails(endPointUrl, identity, credential, zone)) {
+                    final Openstack openstack = Openstack.Factory.get(endPointUrl, identity, credential, zone);
+                    final List<String> values = listAllNames(openstack);
+                    for (String value : values) {
+                        final String displayText = value;
+                        m.add(displayText, value);
+                    }
+                }
+            } catch (AuthenticationException | FormValidation | ConnectionException ex) {
+                LOGGER.log(Level.FINEST, "Openstack call failed", ex);
+            } catch (Exception ex) {
+                LOGGER.log(Level.SEVERE, ex.getMessage(), ex);
+            }
+            if (!hasValue(m, valueOrEmpty)) {
+                m.add(valueOrEmpty);
+            }
+            return m;
+        }
+
+        protected FormValidation checkNameMatchesOnlyOnce(String value, String endPointUrl1, String endPointUrl2,
+                String identity1, String identity2, String credential1, String credential2,
+                String zone1, String zone2) {
+            if (Util.fixEmpty(value) == null)
+                return REQUIRED;
+
+            final String endPointUrl = getDefault(endPointUrl1, endPointUrl2);
+            final String identity = getDefault(identity1, identity2);
+            final String credential = getDefault(credential1, credential2);
+            final String zone = getDefault(zone1, zone2);
+            if (!haveAuthDetails(endPointUrl, identity, credential, zone))
+                return FormValidation.ok();
+
+            final List<String> matches;
+            try {
+                final Openstack openstack = Openstack.Factory.get(endPointUrl, identity, credential, zone);
+                matches = findMatchingIds(openstack, value);
+            } catch (AuthenticationException | FormValidation | ConnectionException ex) {
+                LOGGER.log(Level.FINEST, "Openstack call failed", ex);
+                return FormValidation.warning(ex, "Unable to validate");
+            } catch (Exception ex) {
+                LOGGER.log(Level.SEVERE, ex.getMessage(), ex);
+                return FormValidation.warning(ex, "Unable to validate");
+            }
+
+            final int numberOfMatches = matches.size();
+            if (numberOfMatches < 1)
+                return FormValidation.error("Not found");
+            if (numberOfMatches > 1)
+                return FormValidation.warning("Multiple matching results");
+            return FormValidation.ok();
+        }
+
+        /**
+         * Lists all the IDs (of this kind of {@link BootSource}) matching the
+         * given nameOrId.
+         *
+         * @param openstack
+         *            Means of communicating with the OpenStack service.
+         * @param nameOrId
+         *            The user's selected name (or ID).
+         */
+        public abstract @Nonnull List<String> findMatchingIds(Openstack openstack, String nameOrId);
+
+        /**
+         * Lists all the names (of this kind of {@link BootSource}) that the
+         * user could choose between.
+         * 
+         * @param openstack
+         *            Means of communicating with the OpenStack service.
+         */
+        public abstract List<String> listAllNames(Openstack openstack);
+    }
+
+    public static final class Image extends BootSource {
+        private static final long serialVersionUID = -8309975034351235331L;
+
+        private final @Nonnull String name;
+
+        @DataBoundConstructor
+        public Image(@Nonnull String name) {
+            this.name = name;
+        }
+
+        @Nonnull
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public void setServerBootSource(@Nonnull ServerCreateBuilder builder, @Nonnull Openstack os)
+                throws JCloudsCloud.ProvisioningFailedException {
+            final List<String> matchingIds = getDescriptor().findMatchingIds(os, name);
+            final String id = selectIdFromListAndLogProblems(matchingIds, name, "Images");
+            builder.image(id);
+        }
+
+        @Override
+        public String toString() {
+            return "Image " + name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            final Image image = (Image) o;
+            return this.name.equals(image.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return name.hashCode();
+        }
+
+        @Extension
+        public static final class Desc extends BootSourceDescriptor {
+            @Override
+            public @Nonnull String getDisplayName() {
+                return "Image";
+            }
+
+            @Nonnull
+            @Override
+            public List<String> findMatchingIds(Openstack openstack, String nameOrId) {
+                return openstack.getImageIdsFor(nameOrId);
+            }
+
+            @Nonnull
+            @Override
+            public List<String> listAllNames(Openstack openstack) {
+                final Map<String, ?> images = openstack.getImages();
+                final List<String> allNames = new ArrayList<String>(images.size());
+                allNames.addAll(images.keySet());
+                return allNames;
+            }
+
+            @Restricted(DoNotUse.class)
+            @InjectOsAuth
+            public ListBoxModel doFillNameItems(@QueryParameter String name, @QueryParameter String endPointUrl,
+                    @QueryParameter String identity, @QueryParameter String credential, @QueryParameter String zone) {
+                return makeListBoxModelOfAllNames(name, endPointUrl, identity, credential, zone);
+            }
+
+            @Restricted(DoNotUse.class)
+            public FormValidation doCheckName(@QueryParameter String value,
+                    // authentication fields can be in two places relative to us.
+                    @RelativePath("../..") @QueryParameter("endPointUrl") String endPointUrlCloud,
+                    @RelativePath("../../..") @QueryParameter("endPointUrl") String endPointUrlTemplate,
+                    @RelativePath("../..") @QueryParameter("identity") String identityCloud,
+                    @RelativePath("../../..") @QueryParameter("identity") String identityTemplate,
+                    @RelativePath("../..") @QueryParameter("credential") String credentialCloud,
+                    @RelativePath("../../..") @QueryParameter("credential") String credentialTemplate,
+                    @RelativePath("../..") @QueryParameter("zone") String zoneCloud,
+                    @RelativePath("../../..") @QueryParameter("zone") String zoneTemplate) {
+                return checkNameMatchesOnlyOnce(value, endPointUrlCloud, endPointUrlTemplate, identityCloud, identityTemplate,
+                        credentialCloud, credentialTemplate, zoneCloud, zoneTemplate);
+            }
+        }
+    }
+
+    public static final class VolumeSnapshot extends BootSource {
+        private static final long serialVersionUID = 1629434277902240395L;
+        private final @Nonnull String name;
+
+        @DataBoundConstructor
+        public VolumeSnapshot(@Nonnull String name) {
+            this.name = name;
+        }
+
+        @Nonnull
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public void setServerBootSource(@Nonnull ServerCreateBuilder builder, @Nonnull Openstack os) {
+            final List<String> matchingIds = getDescriptor().findMatchingIds(os, name);
+            final String id = selectIdFromListAndLogProblems(matchingIds, name, "VolumeSnapshots");
+            final BlockDeviceMappingBuilder volumeBuilder = Builders.blockDeviceMapping()
+                    .sourceType(BDMSourceType.SNAPSHOT)
+                    .destinationType(BDMDestType.VOLUME)
+                    .uuid(id)
+                    .deleteOnTermination(true)
+                    .bootIndex(0);
+            builder.blockDevice(volumeBuilder.build());
+        }
+
+        @Override
+        public void afterProvisioning(@Nonnull Server server, @Nonnull Openstack openstack) {
+            /*
+             * OpenStack creates a Volume for the Instance to boot from but it
+             * does not give that Volume a name or description. We do this so
+             * that humans can recognize those Volumes.
+             */
+            final List<String> volumeIds = server.getOsExtendedVolumesAttached();
+            final String instanceId = server.getId();
+            final String instanceName = server.getName();
+            int i = 0;
+            final String newVolumeDescription = "For " + instanceName + " (" + instanceId + "), from VolumeSnapshot "
+                    + name + ".";
+            for (final String volumeId : volumeIds) {
+                final String newVolumeName = instanceName + '[' + (i++) + ']';
+                openstack.setVolumeNameAndDescription(volumeId, newVolumeName, newVolumeDescription);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "VolumeSnapshot " + name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            final VolumeSnapshot that = (VolumeSnapshot) o;
+            return name.equals(that.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return name.hashCode();
+        }
+
+        @Extension
+        public static final class Desc extends BootSourceDescriptor {
+            @Override
+            public @Nonnull String getDisplayName() {
+                return "Volume Snapshot";
+            }
+
+            @Nonnull
+            @Override
+            public List<String> findMatchingIds(Openstack openstack, String nameOrId) {
+                return openstack.getVolumeSnapshotIdsFor(nameOrId);
+            }
+
+            @Nonnull
+            @Override
+            public List<String> listAllNames(Openstack openstack) {
+                final Map<String, ?> images = openstack.getVolumeSnapshots();
+                final List<String> allNames = new ArrayList<String>(images.size());
+                allNames.addAll(images.keySet());
+                return allNames;
+            }
+
+            @Restricted(DoNotUse.class)
+            @OsAuthDescriptor.InjectOsAuth
+            public ListBoxModel doFillNameItems(@QueryParameter String name, @QueryParameter String endPointUrl,
+                    @QueryParameter String identity, @QueryParameter String credential, @QueryParameter String zone) {
+                return makeListBoxModelOfAllNames(name, endPointUrl, identity, credential, zone);
+            }
+
+            @Restricted(DoNotUse.class)
+            public FormValidation doCheckName(@QueryParameter String value,
+                    // authentication fields can be in two places relative to
+                    // us.
+                    @RelativePath("../..") @QueryParameter("endPointUrl") String endPointUrlCloud,
+                    @RelativePath("../../..") @QueryParameter("endPointUrl") String endPointUrlTemplate,
+                    @RelativePath("../..") @QueryParameter("identity") String identityCloud,
+                    @RelativePath("../../..") @QueryParameter("identity") String identityTemplate,
+                    @RelativePath("../..") @QueryParameter("credential") String credentialCloud,
+                    @RelativePath("../../..") @QueryParameter("credential") String credentialTemplate,
+                    @RelativePath("../..") @QueryParameter("zone") String zoneCloud,
+                    @RelativePath("../../..") @QueryParameter("zone") String zoneTemplate) {
+                return checkNameMatchesOnlyOnce(value, endPointUrlCloud, endPointUrlTemplate, identityCloud, identityTemplate,
+                        credentialCloud, credentialTemplate, zoneCloud, zoneTemplate);
+            }
+        }
+    }
+
+    /**
+     * No boot source specified. This exists only as a field in UI dropdown to
+     * be read by stapler and converted to plain old null.
+     */
+    // Therefore, noone refers to this as a symbol or tries to serialize it,
+    // ever.
+    @SuppressWarnings({"unused", "serial"})
+    public static final class Unspecified extends BootSource {
+        private Unspecified() {
+        } // Never instantiate
+
+        @Extension(ordinal = Double.MAX_VALUE) // Make it first and therefore default
+        public static final class Desc extends Descriptor<BootSource> {
+            @Override
+            public @Nonnull String getDisplayName() {
+                return "Inherit / Override later";
+            }
+
+            @Override
+            public BootSource newInstance(StaplerRequest req, @Nonnull JSONObject formData) throws FormException {
+                return null; // Make sure this is never instantiated and hence
+                             // will be treated as absent
+            }
+        }
+    }
+}

--- a/src/main/resources/jenkins/plugins/openstack/compute/SlaveOptions/config.jelly
+++ b/src/main/resources/jenkins/plugins/openstack/compute/SlaveOptions/config.jelly
@@ -17,9 +17,7 @@
         <div name="slaveOptions" descriptorid="${descriptor.id}">
             <table style="width:100%">
                 <f:section title="Cloud Server Options">
-                    <f:entry title="Image" field="imageId">
-                        <f:select/>
-                    </f:entry>
+                    <f:dropdownDescriptorSelector field="bootSource" title="Boot Source"/>
                     <f:entry title="Hardware" field="hardwareId">
                         <f:select/>
                     </f:entry>
@@ -39,7 +37,7 @@
                         <f:textbox/>
                     </f:entry>
                     <f:entry title="Availability Zone" field="availabilityZone">
-                        <f:textbox/>
+                        <f:combobox/>
                     </f:entry>
                     <f:entry title="Startup Timeout" field="startTimeout">
                         <f:textbox/>

--- a/src/main/resources/jenkins/plugins/openstack/compute/SlaveOptions/help-availabilityZone.html
+++ b/src/main/resources/jenkins/plugins/openstack/compute/SlaveOptions/help-availabilityZone.html
@@ -1,3 +1,9 @@
 <div>
-    OpenStack region to use. Can be left blank if the default endpoint region should be used.
+    OpenStack Availability Zone to use.
+    <p/>
+    Can be left blank if the OpenStack deployment is free to put the instance on an availability zone of its choice.
+    e.g. if your OpenStack deployment has only one availability zone, or if all zones are equivalent.
+    <br/>
+    Should not be left blank if there are multiple availability zones that are not equivalent as this can result in non-deterministic behavior.
+    e.g. if you have different zones for different processor architectures then you should choose a zone appropriate for the selected image.
 </div>

--- a/src/main/resources/jenkins/plugins/openstack/compute/SlaveOptions/help-bootSource.html
+++ b/src/main/resources/jenkins/plugins/openstack/compute/SlaveOptions/help-bootSource.html
@@ -1,0 +1,28 @@
+<div>
+  Selects the kind of image to be used as the boot source for the instance.
+  <p/>
+  OpenStack has multiple ways of storing the data necessary for booting up a new instances.
+  This plugin supports the following:
+  <dl>
+  <dt>Image (default)</dt>
+  <dd>
+  A bootable filesystem stored on OpenStack's &quot;image store&quot; subsystem.
+  Images get copied to the &quot;compute node&quot; before being booted.
+  The instance is given a writable copy which is disposed of when the
+  instance itself is destroyed.
+  </dd>
+  <dt>Volume Snapshot</dt>
+  <dd>
+  A bootable filesystem stored on OpenStack's &quot;block storage&quot; subsystem.
+  Booting from a Volume Snapshot requires OpenStack to create a new volume
+  for the instance to boot from, which will automatically be deleted when
+  the instance itself is disposed of.
+  </dd>
+  </dl>
+  OpenStack also supports booting from an
+  &quot;Instance Snapshot&quot;
+  or a
+  &quot;Volume&quot;
+  These methods are unsupported by this plugin but data can be converted,
+  e.g. by creating a Volume Snapshot from a Volume.
+</div>

--- a/src/main/resources/jenkins/plugins/openstack/compute/SlaveOptions/help-imageId.html
+++ b/src/main/resources/jenkins/plugins/openstack/compute/SlaveOptions/help-imageId.html
@@ -1,3 +1,0 @@
-<div>
-  Image ID to use for this slave template.
-</div>

--- a/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/Image/config.jelly
+++ b/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/Image/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="Name" field="name">
+        <f:select/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/Image/help-name.html
+++ b/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/Image/help-name.html
@@ -1,0 +1,7 @@
+<div>
+  Name (or ID) of the image from which to boot this slave template.
+  <br/>
+  The list will be populated with the names of images.
+  <br/>
+  Note: If the name is ambiguous, i.e. there are multiple images with the selected name, then the most recently updated will be used.
+</div>

--- a/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/VolumeSnapshot/config.jelly
+++ b/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/VolumeSnapshot/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="Name" field="name">
+        <f:select/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/VolumeSnapshot/help-name.html
+++ b/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/VolumeSnapshot/help-name.html
@@ -1,0 +1,7 @@
+<div>
+  Name (or ID) of the volume snapshot from which to boot this slave template.
+  <br/>
+  The list will be populated with the names of snapshots.
+  <br/>
+  Note: If the name is ambiguous, i.e. there are multiple snapshots with the selected name, then the most recently updated will be used.
+</div>

--- a/src/test/java/jenkins/plugins/openstack/PluginTestRule.java
+++ b/src/test/java/jenkins/plugins/openstack/PluginTestRule.java
@@ -10,6 +10,7 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,8 +22,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
-import hudson.init.InitMilestone;
-import hudson.init.Initializer;
 import hudson.slaves.Cloud;
 import hudson.slaves.CloudProvisioningListener;
 import hudson.slaves.NodeProvisioner;
@@ -30,10 +29,10 @@ import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
 import jenkins.plugins.openstack.compute.SlaveOptions;
 import jenkins.plugins.openstack.compute.UserDataConfig;
+import jenkins.plugins.openstack.compute.slaveopts.BootSource;
 import jenkins.plugins.openstack.compute.slaveopts.LauncherFactory;
 import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
-import org.jenkinsci.main.modules.sshd.SSHD;
 import org.jenkinsci.plugins.resourcedisposer.AsyncResourceDisposer;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -94,7 +93,8 @@ public final class PluginTestRule extends JenkinsRule {
             dummyUserData("dummyUserDataId");
         }
         return new SlaveOptions(
-                "img", "hw", "nw", "dummyUserDataId", 1, "pool", "sg", "az", 1, null, 10, "jvmo", "fsRoot", LauncherFactory.JNLP.JNLP, 1
+                new BootSource.VolumeSnapshot("id"), "hw", "nw", "dummyUserDataId", 1, "pool", "sg", "az", 1, null, 10,
+                "jvmo", "fsRoot", LauncherFactory.JNLP.JNLP, 1
         );
     }
 
@@ -103,7 +103,7 @@ public final class PluginTestRule extends JenkinsRule {
 
         // Use some real-looking values preserving defaults to make sure plugin works with them
         return JCloudsCloud.DescriptorImpl.getDefaultOptions().getBuilder()
-                .imageId("dummyImageId")
+                .bootSource(new BootSource.Image("dummyImageId"))
                 .hardwareId("dummyHardwareId")
                 .networkId("dummyNetworkId")
                 .userDataId("dummyUserDataId")
@@ -287,8 +287,8 @@ public final class PluginTestRule extends JenkinsRule {
                 return null;
             }
         });
-        doAnswer(new Answer() {
-            @Override public Object answer(InvocationOnMock invocation) throws Throwable {
+        doAnswer(new Answer<Void>() {
+            @Override public Void answer(InvocationOnMock invocation) throws Throwable {
                 Server server = (Server) invocation.getArguments()[0];
                 running.remove(server);
                 return null;
@@ -385,6 +385,7 @@ public final class PluginTestRule extends JenkinsRule {
             when(server.getAddresses()).thenReturn(new NovaAddresses());
             when(server.getStatus()).thenReturn(Server.Status.ACTIVE);
             when(server.getMetadata()).thenReturn(metadata);
+            when(server.getOsExtendedVolumesAttached()).thenReturn(Collections.singletonList(UUID.randomUUID().toString()));
             metadata.put("jenkins-instance", jenkins.getRootUrl()); // Mark the slave as ours
         }
 

--- a/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudTest.java
@@ -30,6 +30,7 @@ import hudson.slaves.Cloud;
 import jenkins.model.Jenkins;
 import jenkins.plugins.openstack.GlobalConfig;
 import jenkins.plugins.openstack.compute.internal.Openstack;
+import jenkins.plugins.openstack.compute.slaveopts.BootSource;
 import jenkins.plugins.openstack.compute.slaveopts.LauncherFactory;
 import org.acegisecurity.AccessDeniedException;
 import org.acegisecurity.acls.sid.Sid;
@@ -135,12 +136,11 @@ public class JCloudsCloudTest {
     public void presentUIDefaults() throws Exception {
         SlaveOptions DEF = DescriptorImpl.getDefaultOptions();
 
-
         JCloudsSlaveTemplate template = new JCloudsSlaveTemplate("template", "label", new SlaveOptions(
-                "img", "hw", "nw", "ud", 1, "public", "sg", "az", 2, "kp", 3, "jvmo", "fsRoot", LauncherFactory.JNLP.JNLP, 4
+                new BootSource.Image("iid"), "hw", "nw", "ud", 1, "public", "sg", "az", 2, "kp", 3, "jvmo", "fsRoot", LauncherFactory.JNLP.JNLP, 4
         ));
         JCloudsCloud cloud = new JCloudsCloud("openstack", "identity", "credential", "endPointUrl", "zone", new SlaveOptions(
-                "IMG", "HW", "NW", "UD", 6, null, "SG", "AZ", 7, "KP", 8, "JVMO", "FSrOOT", new LauncherFactory.SSH("cid"), 9
+                new BootSource.VolumeSnapshot("vsid"), "HW", "NW", "UD", 6, null, "SG", "AZ", 7, "KP", 8, "JVMO", "FSrOOT", new LauncherFactory.SSH("cid"), 9
         ), Collections.singletonList(template));
         j.jenkins.clouds.add(cloud);
 
@@ -244,7 +244,7 @@ public class JCloudsCloudTest {
         assertEquals(Label.parse("label"), template.getLabelSet());
         SlaveOptions to = template.getEffectiveSlaveOptions();
         assertEquals("16", to.getHardwareId());
-        assertEquals("ac98e93d-34a3-437d-a7ba-9ad24c02f5b2", to.getImageId());
+        assertEquals("ac98e93d-34a3-437d-a7ba-9ad24c02f5b2", ((BootSource.Image) to.getBootSource()).getName());
         assertEquals("my-network", to.getNetworkId());
         assertEquals(1, (int) to.getNumExecutors());
         assertEquals(0, (int) to.getRetentionTime()); // overrideRetentionTime though deprecated, should be honored

--- a/src/test/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplateTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplateTest.java
@@ -1,8 +1,10 @@
 package jenkins.plugins.openstack.compute;
 
 import java.io.ByteArrayInputStream;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
@@ -10,20 +12,25 @@ import hudson.remoting.Base64;
 import jenkins.plugins.openstack.PluginTestRule;
 
 import jenkins.plugins.openstack.compute.internal.Openstack;
+import jenkins.plugins.openstack.compute.slaveopts.BootSource;
 import jenkins.plugins.openstack.compute.slaveopts.LauncherFactory;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.openstack4j.model.compute.BDMDestType;
+import org.openstack4j.model.compute.BDMSourceType;
+import org.openstack4j.model.compute.BlockDeviceMappingCreate;
 import org.openstack4j.model.compute.Server;
 import org.openstack4j.model.compute.builder.ServerCreateBuilder;
+import org.openstack4j.openstack.compute.domain.NovaBlockDeviceMappingCreate;
 
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
 
 public class JCloudsSlaveTemplateTest {
 
@@ -75,7 +82,7 @@ public class JCloudsSlaveTemplateTest {
     @Test
     public void eraseDefaults() throws Exception {
         SlaveOptions cloudOpts = PluginTestRule.dummySlaveOptions(); // Make sure nothing collides with defaults
-        SlaveOptions templateOpts = cloudOpts.getBuilder().imageId("42").availabilityZone("other").build();
+        SlaveOptions templateOpts = cloudOpts.getBuilder().bootSource(new BootSource.Image("id")).availabilityZone("other").build();
         assertEquals(cloudOpts.getHardwareId(), templateOpts.getHardwareId());
 
         JCloudsSlaveTemplate template = new JCloudsSlaveTemplate(
@@ -89,7 +96,7 @@ public class JCloudsSlaveTemplateTest {
         );
 
         assertEquals(cloudOpts, cloud.getRawSlaveOptions());
-        assertEquals(SlaveOptions.builder().imageId("42").availabilityZone("other").build(), template.getRawSlaveOptions());
+        assertEquals(SlaveOptions.builder().bootSource(new BootSource.Image("id")).availabilityZone("other").build(), template.getRawSlaveOptions());
     }
 
     @Test
@@ -124,5 +131,62 @@ public class JCloudsSlaveTemplateTest {
 
         verify(os).bootAndWaitActive(any(ServerCreateBuilder.class), anyInt());
         verify(os, never()).assignFloatingIp(any(Server.class), any(String.class));
+    }
+
+    @Test
+    public void bootFromVolumeSnapshot() throws Exception {
+        final String volumeSnapshotName = "MyVolumeSnapshot";
+        final String volumeSnapshotId = "vs-123-id";
+        final SlaveOptions opts = PluginTestRule.dummySlaveOptions().getBuilder().bootSource(new BootSource.VolumeSnapshot(volumeSnapshotName)).build();
+        final JCloudsSlaveTemplate instance = j.dummySlaveTemplate(opts, "a");
+        final JCloudsCloud cloud = j.configureSlaveProvisioning(j.dummyCloud(instance));
+        final Openstack mockOs = cloud.getOpenstack();
+        when(mockOs.getVolumeSnapshotIdsFor(volumeSnapshotName)).thenReturn(Collections.singletonList(volumeSnapshotId));
+        final ArgumentCaptor<ServerCreateBuilder> scbCaptor = ArgumentCaptor.forClass(ServerCreateBuilder.class);
+        final ArgumentCaptor<String> vnCaptor = ArgumentCaptor.forClass(String.class);
+        final ArgumentCaptor<String> vdCaptor = ArgumentCaptor.forClass(String.class);
+
+        final Server actual = instance.provision(cloud);
+
+        final String actualServerName = actual.getName();
+        final String actualServerId = actual.getId();
+        verify(mockOs, times(1)).bootAndWaitActive(scbCaptor.capture(), anyInt());
+        verify(mockOs, times(1)).setVolumeNameAndDescription(anyString(), vnCaptor.capture(), vdCaptor.capture());
+        final ServerCreateBuilder scbActual = scbCaptor.getValue();
+        final List<BlockDeviceMappingCreate> blockDeviceMappingActual = (List<BlockDeviceMappingCreate>)readPrivateField(readPrivateField(scbActual, "m"), "blockDeviceMapping");
+        assertThat(blockDeviceMappingActual, hasSize(1));
+        final NovaBlockDeviceMappingCreate bdmcActual = (NovaBlockDeviceMappingCreate)blockDeviceMappingActual.get(0);
+        assertThat(bdmcActual.boot_index, equalTo(0));
+        assertThat(bdmcActual.delete_on_termination, equalTo(true));
+        assertThat(bdmcActual.uuid, equalTo(volumeSnapshotId));
+        assertThat(bdmcActual.source_type, equalTo(BDMSourceType.SNAPSHOT));
+        assertThat(bdmcActual.destination_type, equalTo(BDMDestType.VOLUME));
+        final String actualVolumeName = vnCaptor.getValue();
+        assertThat(actualVolumeName, equalTo(actualServerName+"[0]"));
+        final String actualVolumeDescription = vdCaptor.getValue();
+        assertThat(actualVolumeDescription, containsString(actualServerName));
+        assertThat(actualVolumeDescription, containsString(actualServerId));
+        assertThat(actualVolumeDescription, containsString(volumeSnapshotName));
+    }
+
+    private static Object readPrivateField(Object object, String fieldName) {
+        final StringBuilder msg = new StringBuilder();
+        final Class<?> clazz = object.getClass();
+        try {
+            msg.append("Unable to read field '").append(fieldName).append("' from ").append(object)
+                    .append(".  Known fields are:");
+            for (Class<?> c = clazz; c != null; c = c.getSuperclass()) {
+                msg.append("\n").append(c).append(":");
+                for (Field f : c.getDeclaredFields()) {
+                    msg.append("\n  ").append(f);
+                }
+            }
+            final Field field = clazz.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            Object value = field.get(object);
+            return value;
+        } catch (Exception e) {
+            throw new AssertionError(msg.toString(), e);
+        }
     }
 }

--- a/src/test/java/jenkins/plugins/openstack/compute/ProvisioningTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/ProvisioningTest.java
@@ -13,9 +13,13 @@ import hudson.model.TaskListener;
 import hudson.model.labels.LabelAtom;
 import hudson.plugins.sshslaves.SSHLauncher;
 import hudson.slaves.NodeProvisioner;
+import hudson.slaves.NodeProvisioner.PlannedNode;
 import jenkins.plugins.openstack.PluginTestRule;
 import jenkins.plugins.openstack.compute.internal.Openstack;
+import jenkins.plugins.openstack.compute.slaveopts.BootSource;
 import jenkins.plugins.openstack.compute.slaveopts.LauncherFactory;
+
+import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.cloudstats.CloudStatistics;
 import org.jenkinsci.plugins.cloudstats.ProvisioningActivity;
@@ -25,8 +29,13 @@ import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.mockito.ArgumentCaptor;
+import org.mockito.internal.util.reflection.Whitebox;
+import org.openstack4j.model.compute.BDMDestType;
+import org.openstack4j.model.compute.BDMSourceType;
+import org.openstack4j.model.compute.BlockDeviceMappingCreate;
 import org.openstack4j.model.compute.Server;
 import org.openstack4j.model.compute.builder.ServerCreateBuilder;
+import org.openstack4j.openstack.compute.domain.NovaBlockDeviceMappingCreate;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -133,7 +142,7 @@ public class ProvisioningTest {
         verify(os, times(2)).updateInfo(any(Server.class));
         verify(os, atLeastOnce()).destroyServer(any(Server.class));
         verify(os, atLeastOnce()).getServerById(any(String.class));
-        verify(os, atLeastOnce()).getImageIdFor(any(String.class));
+        verify(os, atLeastOnce()).getImageIdsFor(any(String.class));
 
         verifyNoMoreInteractions(os);
 
@@ -275,12 +284,12 @@ public class ProvisioningTest {
 
     @Test
     public void allowToUseImageNameAsWellAsId() throws Exception {
-        SlaveOptions opts = j.defaultSlaveOptions().getBuilder().imageId("image-id").build();
+        SlaveOptions opts = j.defaultSlaveOptions().getBuilder().bootSource(new BootSource.Image("image-id")).build();
         JCloudsCloud cloud = j.configureSlaveLaunching(j.dummyCloud(j.dummySlaveTemplate(opts, "label")));
 
         Openstack os = cloud.getOpenstack();
         // simulate same image resolved to different ids
-        when(os.getImageIdFor(eq("image-id"))).thenReturn("image-id", "something-else");
+        when(os.getImageIdsFor(eq("image-id"))).thenReturn(Collections.singletonList("image-id")).thenReturn(Collections.singletonList("something-else"));
 
         j.provision(cloud, "label"); j.provision(cloud, "label");
 
@@ -291,6 +300,40 @@ public class ProvisioningTest {
         assertEquals(2, builders.size());
         assertEquals("image-id", builders.get(0).build().getImageRef());
         assertEquals("something-else", builders.get(1).build().getImageRef());
+    }
+
+    @Test
+    public void allowToUseVolumeSnapshotNameAsWellAsId() throws Exception {
+        SlaveOptions opts = j.defaultSlaveOptions().getBuilder().bootSource(new BootSource.VolumeSnapshot("vs-id")).build();
+        JCloudsCloud cloud = j.configureSlaveLaunching(j.dummyCloud(j.dummySlaveTemplate(opts, "label")));
+
+        Openstack os = cloud.getOpenstack();
+        // simulate same snapshot resolved to different ids
+        when(os.getVolumeSnapshotIdsFor(eq("vs-id"))).thenReturn(Collections.singletonList("vs-id")).thenReturn(Collections.singletonList("something-else"));
+
+        j.provision(cloud, "label"); j.provision(cloud, "label");
+
+        ArgumentCaptor<ServerCreateBuilder> captor = ArgumentCaptor.forClass(ServerCreateBuilder.class);
+        verify(os, times(2)).bootAndWaitActive(captor.capture(), any(Integer.class));
+
+        List<ServerCreateBuilder> builders = captor.getAllValues();
+        assertEquals(2, builders.size());
+        assertEquals("vs-id", getVolumeSnapshotId(builders.get(0)));
+        assertEquals("something-else", getVolumeSnapshotId(builders.get(1)));
+    }
+
+    @SuppressWarnings("unchecked")
+    private String getVolumeSnapshotId(ServerCreateBuilder builder) {
+        List<BlockDeviceMappingCreate> mapping = (List<BlockDeviceMappingCreate>) Whitebox.getInternalState(
+                builder.build(),
+                "blockDeviceMapping"
+        );
+
+        assertEquals(1, mapping.size());
+        NovaBlockDeviceMappingCreate device = (NovaBlockDeviceMappingCreate) mapping.get(0);
+        assertEquals(BDMSourceType.SNAPSHOT, device.source_type);
+        assertEquals(BDMDestType.VOLUME, device.destination_type);
+        return device.uuid;
     }
 
     @Test
@@ -437,13 +480,16 @@ public class ProvisioningTest {
 
     @Test
     public void timeoutLaunching() throws Exception {
-        SlaveOptions opts = j.defaultSlaveOptions().getBuilder().startTimeout(1000).build();
-        JCloudsCloud cloud = j.configureSlaveProvisioning(j.dummyCloud(opts, j.dummySlaveTemplate("asdf")));
-        Collection<NodeProvisioner.PlannedNode> pns = cloud.provision(Label.get("asdf"), 1);
-        assertThat(pns, Matchers.<NodeProvisioner.PlannedNode>iterableWithSize(1));
+        final SlaveOptions opts = j.defaultSlaveOptions().getBuilder().startTimeout(1000).build();
+        final JCloudsCloud cloud = j.configureSlaveProvisioning(j.dummyCloud(opts, j.dummySlaveTemplate("asdf")));
+        final Iterable<NodeProvisioner.PlannedNode> pns = cloud.provision(Label.get("asdf"), 1);
+        final Matcher<Iterable<NodeProvisioner.PlannedNode>> hasOnlyOneElement = iterableWithSize(1);
+        assertThat(pns, hasOnlyOneElement);
+        final PlannedNode pn = pns.iterator().next();
+        final Future<Node> pnf = pn.future;
 
         try {
-            pns.iterator().next().future.get();
+            pnf.get();
             fail();
         } catch (ExecutionException ex) {
             assertThat(ex.getCause(), instanceOf(JCloudsCloud.ProvisioningFailedException.class));

--- a/src/test/java/jenkins/plugins/openstack/compute/SlaveOptionsDescriptorTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/SlaveOptionsDescriptorTest.java
@@ -1,5 +1,6 @@
 package jenkins.plugins.openstack.compute;
 
+import hudson.util.ComboBoxModel;
 import hudson.util.FormValidation;
 import static hudson.util.FormValidation.Kind.*;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -10,30 +11,24 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import hudson.util.ListBoxModel;
 import jenkins.plugins.openstack.PluginTestRule;
 import jenkins.plugins.openstack.compute.internal.Openstack;
 import org.hamcrest.Description;
-import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.Issue;
-import org.openstack4j.api.OSClient;
 import org.openstack4j.api.exceptions.AuthenticationException;
-import org.openstack4j.api.image.ImageService;
-import org.openstack4j.model.image.Image;
-import org.openstack4j.openstack.image.domain.GlanceImage;
+import org.openstack4j.model.compute.ext.AvailabilityZone;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
@@ -109,7 +104,7 @@ public class SlaveOptionsDescriptorTest {
         assertThat(d.doCheckRetentionTime("err", "1"), hasState(ERROR, "Not a number"));
     }
 
-    public TypeSafeMatcher<FormValidation> hasState(final FormValidation.Kind kind, final String msg) {
+    public static TypeSafeMatcher<FormValidation> hasState(final FormValidation.Kind kind, final String msg) {
         return new TypeSafeMatcher<FormValidation>() {
             @Override
             public void describeTo(Description description) {
@@ -128,44 +123,124 @@ public class SlaveOptionsDescriptorTest {
         };
     }
 
-    @Test
-    public void populateImageNamesNotIds() {
-        Image image = new GlanceImage();
-        image.setId("image-id");
-        image.setName("image-name");
+    public static TypeSafeMatcher<FormValidation> hasState(final FormValidation expected) {
+        return new TypeSafeMatcher<FormValidation>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText(expected.kind.toString() + ": " + expected.getMessage());
+            }
 
-        Openstack os = j.fakeOpenstackFactory();
-        doReturn(Collections.singletonList(image)).when(os).getSortedImages();
+            @Override
+            protected void describeMismatchSafely(FormValidation item, Description mismatchDescription) {
+                mismatchDescription.appendText(item.kind + ": " + item.getMessage());
+            }
 
-        ListBoxModel list = d.doFillImageIdItems("not-needed", "", "", "", "");
-        assertEquals(2, list.size());
-        ListBoxModel.Option item = list.get(1);
-        assertEquals("image-name", item.name);
-        assertEquals("image-name", item.value);
+            @Override
+            protected boolean matchesSafely(FormValidation item) {
+                return expected.kind.equals(item.kind) && Objects.equals(item.getMessage(), expected.getMessage());
+            }
+        };
     }
 
-    @Test @Issue("JENKINS-29993")
-    public void acceptNullAsImageName() {
-        Image image = new GlanceImage();
-        image.setId("image-id");
-        image.setName(null);
+    @Test
+    public void doFillAvailabilityZoneItemsGivenAZsThenPopulatesList() {
+        final AvailabilityZone az1 = mock(AvailabilityZone.class, "az1");
+        final AvailabilityZone az2 = mock(AvailabilityZone.class, "az2");
+        when(az1.getZoneName()).thenReturn("az1Name");
+        when(az2.getZoneName()).thenReturn("az2Name");
+        final List<AvailabilityZone> azs = Arrays.asList(az1, az2);
+        final Openstack os = j.fakeOpenstackFactory();
+        doReturn(azs).when(os).getAvailabilityZones();
 
-        OSClient osClient = mock(OSClient.class);
-        ImageService imageService = mock(ImageService.class);
-        when(osClient.images()).thenReturn(imageService);
-        doReturn(Collections.singletonList(image)).when(imageService).listAll();
+        final ComboBoxModel actual = d.doFillAvailabilityZoneItems("az2Name", "OSurl", "OSid", "OSpwd", "OSzone");
 
-        j.fakeOpenstackFactory(new Openstack(osClient));
+        assertEquals(2, actual.size());
+        final String az1Option = actual.get(0);
+        assertThat(az1Option, equalTo("az1Name"));
+        final String az2Option = actual.get(1);
+        assertThat(az2Option, equalTo("az2Name"));
+    }
 
-        ListBoxModel list = d.doFillImageIdItems("not-needed", "", "", "", "");
-        assertThat(list.get(0).name, list, Matchers.<ListBoxModel.Option>iterableWithSize(2));
-        assertEquals(2, list.size());
-        ListBoxModel.Option item = list.get(1);
-        assertEquals("image-id", item.name);
-        assertEquals("image-id", item.value);
+    @Test
+    public void doFillAvailabilityZoneItemsGivenNoSupportForAZsThenGivesEmptyList() {
+        final Openstack os = j.fakeOpenstackFactory();
+        doThrow(new RuntimeException("OpenStack said no")).when(os).getAvailabilityZones();
 
-        verify(imageService).listAll();
-        verifyNoMoreInteractions(imageService);
+        final ComboBoxModel actual = d.doFillAvailabilityZoneItems("az2Name", "OSurl", "OSid", "OSpwd", "OSzone");
+
+        assertEquals(0, actual.size());
+    }
+
+    @Test
+    public void doCheckAvailabilityZoneGivenAZThenReturnsOK() throws Exception {
+        final String value = "chosenAZ";
+        final String def = "";
+        final Openstack os = j.fakeOpenstackFactory();
+        final FormValidation expected = FormValidation.ok();
+
+        final FormValidation actual = d.doCheckAvailabilityZone(value, def, "OSurl", "OSurl", "OSid", "OSid", "OSpwd", "OSpwd", "OSzone", "OSzone");
+
+        assertThat(actual, hasState(expected));
+        verifyNoMoreInteractions(os);
+    }
+
+    @Test
+    public void doCheckAvailabilityZoneGivenDefaultAZThenReturnsOKWithDefault() throws Exception {
+        final String value = "";
+        final String def = "defaultAZ";
+        final Openstack os = j.fakeOpenstackFactory();
+
+        final FormValidation actual = d.doCheckAvailabilityZone(value, def, "OSurl", "OSurl", "OSid", "OSid", "OSpwd", "OSpwd", "OSzone", "OSzone");
+
+        assertThat(actual, hasState(OK, "Inherited value: " + def));
+        verifyNoMoreInteractions(os);
+    }
+
+    @Test
+    public void doCheckAvailabilityZoneGivenNoAZAndOnlyOneZoneToChooseFromThenReturnsOK() throws Exception {
+        final AvailabilityZone az1 = mock(AvailabilityZone.class, "az1");
+        when(az1.getZoneName()).thenReturn("az1Name");
+        final List<AvailabilityZone> azs = Arrays.asList(az1);
+        final Openstack os = j.fakeOpenstackFactory();
+        doReturn(azs).when(os).getAvailabilityZones();
+        final String value = "";
+        final String def = "";
+        final FormValidation expected = FormValidation.ok();
+
+        final FormValidation actual = d.doCheckAvailabilityZone(value, def, "OSurl", "OSurl", "OSid", "OSid", "OSpwd", "OSpwd", "OSzone", "OSzone");
+
+        assertThat(actual, hasState(expected));
+    }
+
+    @Test
+    public void doCheckAvailabilityZoneGivenNoAZAndNoSupportForAZsThenReturnsOK() throws Exception {
+        final Openstack os = j.fakeOpenstackFactory();
+        doThrow(new RuntimeException("OpenStack said no")).when(os).getAvailabilityZones();
+        final String value = "";
+        final String def = "";
+        final FormValidation expected = FormValidation.ok();
+
+        final FormValidation actual = d.doCheckAvailabilityZone(value, def, "OSurl", "OSurl", "OSid", "OSid", "OSpwd", "OSpwd", "OSzone", "OSzone");
+
+        assertThat(actual, hasState(expected));
+    }
+
+    @Test
+    public void doCheckAvailabilityZoneGivenNoAZAndMultipleZoneToChooseFromThenReturnsWarning() throws Exception {
+        final AvailabilityZone az1 = mock(AvailabilityZone.class, "az1");
+        final AvailabilityZone az2 = mock(AvailabilityZone.class, "az2");
+        when(az1.getZoneName()).thenReturn("az1Name");
+        when(az2.getZoneName()).thenReturn("az2Name");
+        final List<AvailabilityZone> azs = Arrays.asList(az1, az2);
+        final Openstack os = j.fakeOpenstackFactory();
+        doReturn(azs).when(os).getAvailabilityZones();
+        final String value = "";
+        final String def = "";
+        final FormValidation expected = FormValidation.warning("Ambiguity warning: Multiple zones found.");
+
+        final FormValidation actual = d.doCheckAvailabilityZone(value, def, "OSurl", "OSurl", "OSid", "OSid", "OSpwd", "OSpwd", "OSzone", "OSzone");
+
+        assertThat(actual, hasState(expected));
     }
 
     @Test
@@ -180,12 +255,10 @@ public class SlaveOptionsDescriptorTest {
         assertThat(getFillDependencies("keyPairName"), equalTo(expected));
         assertThat(getFillDependencies("floatingIpPool"), equalTo(expected));
         assertThat(getFillDependencies("hardwareId"), equalTo(expected));
-        assertThat(getFillDependencies("imageId"), equalTo(expected));
         assertThat(getFillDependencies("networkId"), equalTo(expected));
 
         assertFillWorks("floatingIpPool");
         assertFillWorks("hardwareId");
-        assertFillWorks("imageId");
         assertFillWorks("networkId");
         assertFillWorks("keyPairName");
     }

--- a/src/test/java/jenkins/plugins/openstack/compute/SlaveOptionsTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/SlaveOptionsTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.*;
 
 import jenkins.plugins.openstack.PluginTestRule;
+import jenkins.plugins.openstack.compute.slaveopts.BootSource;
 import jenkins.plugins.openstack.compute.slaveopts.LauncherFactory;
 import org.junit.Test;
 
@@ -16,7 +17,7 @@ public class SlaveOptionsTest {
     public void defaultOverrides() {
         SlaveOptions unmodified = PluginTestRule.dummySlaveOptions().override(SlaveOptions.empty());
 
-        assertEquals("img", unmodified.getImageId());
+        assertEquals(new BootSource.VolumeSnapshot("id"), unmodified.getBootSource());
         assertEquals("hw", unmodified.getHardwareId());
         assertEquals("nw", unmodified.getNetworkId());
         assertEquals("dummyUserDataId", unmodified.getUserDataId());
@@ -33,7 +34,7 @@ public class SlaveOptionsTest {
         assertEquals(1, (int) unmodified.getRetentionTime());
 
         SlaveOptions override = SlaveOptions.builder()
-                .imageId("IMG")
+                .bootSource(new BootSource.Image("iid"))
                 .hardwareId("HW")
                 .networkId("NW")
                 .userDataId("UD")
@@ -52,7 +53,7 @@ public class SlaveOptionsTest {
         ;
         SlaveOptions overridden = PluginTestRule.dummySlaveOptions().override(override);
 
-        assertEquals("IMG", overridden.getImageId());
+        assertEquals(new BootSource.Image("iid"), overridden.getBootSource());
         assertEquals("HW", overridden.getHardwareId());
         assertEquals("NW", overridden.getNetworkId());
         assertEquals("UD", overridden.getUserDataId());
@@ -71,12 +72,12 @@ public class SlaveOptionsTest {
 
     @Test
     public void eraseDefaults() {
-        SlaveOptions defaults = SlaveOptions.builder().imageId("img").hardwareId("hw").networkId(null).floatingIpPool("a").build();
-        SlaveOptions configured = SlaveOptions.builder().imageId("IMG").hardwareId("hw").networkId("MW").floatingIpPool("A").build();
+        SlaveOptions defaults = SlaveOptions.builder().bootSource(new BootSource.Image("ID")).hardwareId("hw").networkId(null).floatingIpPool("a").build();
+        SlaveOptions configured = SlaveOptions.builder().bootSource(new BootSource.Image("ID")).hardwareId("hw").networkId("MW").floatingIpPool("A").build();
 
         SlaveOptions actual = configured.eraseDefaults(defaults);
 
-        SlaveOptions expected = SlaveOptions.builder().imageId("IMG").hardwareId(null).networkId("MW").floatingIpPool("A").build();
+        SlaveOptions expected = SlaveOptions.builder().bootSource(null).hardwareId(null).networkId("MW").floatingIpPool("A").build();
         assertEquals(expected, actual);
         assertEquals(configured, defaults.override(actual));
     }
@@ -85,10 +86,9 @@ public class SlaveOptionsTest {
     public void emptyStrings() {
         SlaveOptions nulls = SlaveOptions.empty();
         SlaveOptions emptyStrings = new SlaveOptions(
-                "", "", "", "", null, "", "", "", null, "", null, "", "", null, null
+                null, "", "", "", null, "", "", "", null, "", null, "", "", null, null
         );
         SlaveOptions emptyBuilt = SlaveOptions.builder()
-                .imageId("")
                 .hardwareId("")
                 .networkId("")
                 .userDataId("")
@@ -103,7 +103,6 @@ public class SlaveOptionsTest {
         assertEquals(nulls, emptyStrings);
         assertEquals(nulls, emptyBuilt);
 
-        assertEquals(null, emptyStrings.getImageId());
         assertEquals(null, emptyStrings.getHardwareId());
         assertEquals(null, emptyStrings.getNetworkId());
         assertEquals(null, emptyStrings.getUserDataId());

--- a/src/test/java/jenkins/plugins/openstack/compute/internal/OpenstackTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/internal/OpenstackTest.java
@@ -4,6 +4,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyMapOf;
+import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.*;
 
 import org.hamcrest.Matchers;
@@ -13,20 +16,356 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.openstack4j.api.OSClient;
 import org.openstack4j.api.compute.ComputeFloatingIPService;
+import org.openstack4j.api.compute.ext.ZoneService;
 import org.openstack4j.api.exceptions.ClientResponseException;
+import org.openstack4j.api.image.ImageService;
+import org.openstack4j.api.storage.BlockVolumeSnapshotService;
 import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.Fault;
 import org.openstack4j.model.compute.FloatingIP;
 import org.openstack4j.model.compute.Server;
 import org.openstack4j.model.compute.builder.ServerCreateBuilder;
+import org.openstack4j.model.compute.ext.AvailabilityZone;
+import org.openstack4j.model.image.Image;
+import org.openstack4j.model.storage.block.Volume;
+import org.openstack4j.model.storage.block.VolumeSnapshot;
 import org.openstack4j.openstack.compute.domain.NovaFloatingIP;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
+@SuppressWarnings({
+        "rawtypes",
+        "unchecked"
+})
 public class OpenstackTest {
+
+    @Test
+    public void getImagesReturnsImagesIndexedByNameSortedByAge() {
+        final Image mockImageWithNullName = mock(Image.class);
+        when(mockImageWithNullName.getId()).thenReturn("mockImageWithNullNameId");
+        final Image mockImageNamedFoo = mock(Image.class);
+        when(mockImageNamedFoo.getId()).thenReturn("mockImageNamedFooId");
+        when(mockImageNamedFoo.getName()).thenReturn("Foo");
+        final Image mockImageNamedBar1 = mock(Image.class);
+        when(mockImageNamedBar1.getId()).thenReturn("mockImageNamedBar1Id");
+        when(mockImageNamedBar1.getName()).thenReturn("Bar");
+        when(mockImageNamedBar1.getUpdatedAt()).thenReturn(new Date(11111));
+        when(mockImageNamedBar1.getCreatedAt()).thenReturn(new Date(1111));
+        final Image mockImageNamedBar2 = mock(Image.class);
+        when(mockImageNamedBar2.getId()).thenReturn("mockImageNamedBar2Id");
+        when(mockImageNamedBar2.getName()).thenReturn("Bar");
+        when(mockImageNamedBar2.getUpdatedAt()).thenReturn(new Date(10000));
+        when(mockImageNamedBar2.getCreatedAt()).thenReturn(new Date(1111));
+        final Image mockImageNamedBar3 = mock(Image.class);
+        when(mockImageNamedBar3.getId()).thenReturn("mockImageNamedBar3Id");
+        when(mockImageNamedBar3.getName()).thenReturn("Bar");
+        when(mockImageNamedBar3.getUpdatedAt()).thenReturn(new Date(11111));
+        when(mockImageNamedBar3.getCreatedAt()).thenReturn(new Date(1000));
+        final List images = Arrays.asList(mockImageNamedBar1, mockImageWithNullName, mockImageNamedBar2,
+                mockImageNamedFoo, mockImageNamedBar3);
+        final OSClient mockClient = mock(OSClient.class, RETURNS_DEEP_STUBS);
+        when(mockClient.images().listAll()).thenReturn(images);
+        final Collection<Image> images0 = new ArrayList<>(
+                Arrays.asList(mockImageNamedBar2, mockImageNamedBar3, mockImageNamedBar1));
+        final Collection<Image> images1 = new ArrayList<>(Arrays.asList(mockImageNamedFoo));
+        final Collection<Image> images2 = new ArrayList<>(Arrays.asList(mockImageWithNullName));
+
+        final Openstack instance = new Openstack(mockClient);
+        final Map<String, Collection<Image>> actual = instance.getImages();
+
+        // Result keys should be in name order
+        final Iterator<Map.Entry<String, Collection<Image>>> iterator = actual.entrySet().iterator();
+        final Map.Entry<String, Collection<Image>> entry0 = iterator.next();
+        assertThat(entry0.getKey(), equalTo("Bar"));
+        assertThat(new ArrayList<>(entry0.getValue()), equalTo(images0));
+        final Map.Entry<String, Collection<Image>> entry1 = iterator.next();
+        assertThat(entry1.getKey(), equalTo("Foo"));
+        assertThat(new ArrayList<>(entry1.getValue()), equalTo(images1));
+        final Map.Entry<String, Collection<Image>> entry2 = iterator.next();
+        assertThat(entry2.getKey(), equalTo("mockImageWithNullNameId"));
+        assertThat(new ArrayList<>(entry2.getValue()), equalTo(images2));
+        assertThat(iterator.hasNext(), equalTo(false));
+    }
+
+    @Test
+    public void getVolumeSnapshotsReturnsVolumeSnapshotsIndexedByNameSortedByAge() {
+        final VolumeSnapshot mockVolumeSnapshotWithNullName = mock(VolumeSnapshot.class);
+        when(mockVolumeSnapshotWithNullName.getId()).thenReturn("mockVolumeSnapshotWithNullNameId");
+        when(mockVolumeSnapshotWithNullName.getStatus()).thenReturn(Volume.Status.AVAILABLE);
+        final VolumeSnapshot mockVolumeSnapshotNamedFoo = mock(VolumeSnapshot.class);
+        when(mockVolumeSnapshotNamedFoo.getId()).thenReturn("mockVolumeSnapshotNamedFooId");
+        when(mockVolumeSnapshotNamedFoo.getName()).thenReturn("Foo");
+        when(mockVolumeSnapshotNamedFoo.getStatus()).thenReturn(Volume.Status.AVAILABLE);
+        final VolumeSnapshot mockVolumeSnapshotNamedBar1 = mock(VolumeSnapshot.class);
+        when(mockVolumeSnapshotNamedBar1.getId()).thenReturn("mockVolumeSnapshotNamedBar1Id");
+        when(mockVolumeSnapshotNamedBar1.getName()).thenReturn("Bar");
+        when(mockVolumeSnapshotNamedBar1.getCreated()).thenReturn(new Date(11111));
+        when(mockVolumeSnapshotNamedBar1.getStatus()).thenReturn(Volume.Status.AVAILABLE);
+        final VolumeSnapshot mockVolumeSnapshotNamedBar2 = mock(VolumeSnapshot.class);
+        when(mockVolumeSnapshotNamedBar2.getId()).thenReturn("mockVolumeSnapshotNamedBar2Id");
+        when(mockVolumeSnapshotNamedBar2.getName()).thenReturn("Bar");
+        when(mockVolumeSnapshotNamedBar2.getCreated()).thenReturn(new Date(10000));
+        when(mockVolumeSnapshotNamedBar2.getStatus()).thenReturn(Volume.Status.AVAILABLE);
+        final VolumeSnapshot mockVolumeSnapshotNamedBar3 = mock(VolumeSnapshot.class);
+        when(mockVolumeSnapshotNamedBar3.getId()).thenReturn("mockVolumeSnapshotNamedBar3Id");
+        when(mockVolumeSnapshotNamedBar3.getName()).thenReturn("Bar");
+        when(mockVolumeSnapshotNamedBar3.getCreated()).thenReturn(new Date(11110));
+        when(mockVolumeSnapshotNamedBar3.getStatus()).thenReturn(Volume.Status.AVAILABLE);
+        final VolumeSnapshot mockVolumeSnapshotUnavailable = mock(VolumeSnapshot.class);
+        when(mockVolumeSnapshotUnavailable.getId()).thenReturn("mockVolumeSnapshotUnavailable");
+        when(mockVolumeSnapshotUnavailable.getName()).thenReturn("ShouldNotBeInResult");
+        when(mockVolumeSnapshotUnavailable.getCreated()).thenReturn(new Date(123));
+        when(mockVolumeSnapshotUnavailable.getStatus()).thenReturn(Volume.Status.ATTACHING);
+        final List volumeSnapshots = Arrays.asList(mockVolumeSnapshotNamedBar1, mockVolumeSnapshotWithNullName,
+                mockVolumeSnapshotNamedBar2, mockVolumeSnapshotNamedFoo, mockVolumeSnapshotNamedBar3, mockVolumeSnapshotUnavailable);
+        final OSClient mockClient = mock(OSClient.class, RETURNS_DEEP_STUBS);
+        when(mockClient.blockStorage().snapshots().list()).thenReturn(volumeSnapshots);
+        final Collection<VolumeSnapshot> volumeSnapshots0 = new ArrayList<>(
+                Arrays.asList(mockVolumeSnapshotNamedBar2, mockVolumeSnapshotNamedBar3, mockVolumeSnapshotNamedBar1));
+        final Collection<VolumeSnapshot> volumeSnapshots1 = new ArrayList<>(Arrays.asList(mockVolumeSnapshotNamedFoo));
+        final Collection<VolumeSnapshot> volumeSnapshots2 = new ArrayList<>(
+                Arrays.asList(mockVolumeSnapshotWithNullName));
+
+        final Openstack instance = new Openstack(mockClient);
+        final Map<String, Collection<VolumeSnapshot>> actual = instance.getVolumeSnapshots();
+
+        // Result keys should be in name order
+        final Iterator<Map.Entry<String, Collection<VolumeSnapshot>>> iterator = actual.entrySet().iterator();
+        final Map.Entry<String, Collection<VolumeSnapshot>> entry0 = iterator.next();
+        assertThat(entry0.getKey(), equalTo("Bar"));
+        assertThat(new ArrayList<>(entry0.getValue()), equalTo(volumeSnapshots0));
+        final Map.Entry<String, Collection<VolumeSnapshot>> entry1 = iterator.next();
+        assertThat(entry1.getKey(), equalTo("Foo"));
+        assertThat(new ArrayList<>(entry1.getValue()), equalTo(volumeSnapshots1));
+        final Map.Entry<String, Collection<VolumeSnapshot>> entry2 = iterator.next();
+        assertThat(entry2.getKey(), equalTo("mockVolumeSnapshotWithNullNameId"));
+        assertThat(new ArrayList<>(entry2.getValue()), equalTo(volumeSnapshots2));
+        assertThat(iterator.hasNext(), equalTo(false));
+    }
+
+    @Test
+    public void getImageIdsForGivenNameThenReturnsMatchingImageIdsSortedByAge() {
+        final Image mockImageNamedBar1 = mock(Image.class);
+        when(mockImageNamedBar1.getId()).thenReturn("mockImageNamedBar1Id");
+        when(mockImageNamedBar1.getName()).thenReturn("Bar");
+        when(mockImageNamedBar1.getUpdatedAt()).thenReturn(new Date(11111));
+        when(mockImageNamedBar1.getCreatedAt()).thenReturn(new Date(1111));
+        final Image mockImageNamedBar2 = mock(Image.class);
+        when(mockImageNamedBar2.getId()).thenReturn("mockImageNamedBar2Id");
+        when(mockImageNamedBar2.getName()).thenReturn("Bar");
+        when(mockImageNamedBar2.getUpdatedAt()).thenReturn(new Date(10000));
+        when(mockImageNamedBar2.getCreatedAt()).thenReturn(new Date(1111));
+        final Image mockImageNamedBar3 = mock(Image.class);
+        when(mockImageNamedBar3.getId()).thenReturn("mockImageNamedBar3Id");
+        when(mockImageNamedBar3.getName()).thenReturn("Bar");
+        when(mockImageNamedBar3.getUpdatedAt()).thenReturn(new Date(11111));
+        when(mockImageNamedBar3.getCreatedAt()).thenReturn(new Date(1000));
+        final ImageService mockIS = mock(ImageService.class);
+        final List images = Arrays.asList(mockImageNamedBar1, mockImageNamedBar2, mockImageNamedBar3);
+        when(mockIS.listAll(anyMapOf(String.class, String.class))).thenReturn(images);
+        final ArrayList<String> expected = new ArrayList<>(
+                Arrays.asList("mockImageNamedBar2Id", "mockImageNamedBar3Id", "mockImageNamedBar1Id"));
+        final OSClient mockClient = mock(OSClient.class);
+        when(mockClient.images()).thenReturn(mockIS);
+
+        final Openstack instance = new Openstack(mockClient);
+        final List<String> actual = instance.getImageIdsFor("Bar");
+
+        final Map<String, String> expectedFilteringParams = new HashMap<>(2);
+        expectedFilteringParams.put("name", "Bar");
+        expectedFilteringParams.put("status", "active");
+        verify(mockIS).listAll(argThat(equalTo(expectedFilteringParams)));
+        verifyNoMoreInteractions(mockIS);
+        assertThat(new ArrayList<>(actual), equalTo(expected));
+    }
+
+    @Test
+    public void getImageIdsForGivenUnknownThenReturnsEmpty() {
+        final ImageService mockIS = mock(ImageService.class);
+        when(mockIS.listAll(anyMapOf(String.class, String.class))).thenReturn(Collections.EMPTY_LIST);
+        final OSClient mockClient = mock(OSClient.class);
+        when(mockClient.images()).thenReturn(mockIS);
+        final ArrayList<String> expected = new ArrayList<>();
+
+        final Openstack instance = new Openstack(mockClient);
+        final List<String> actual = instance.getImageIdsFor("NameNotFound");
+
+        final Map<String, String> expectedFilteringParams = new HashMap<>(2);
+        expectedFilteringParams.put("name", "NameNotFound");
+        expectedFilteringParams.put("status", "active");
+        verify(mockIS).listAll(argThat(equalTo(expectedFilteringParams)));
+        verifyNoMoreInteractions(mockIS);
+        assertThat(new ArrayList<>(actual), equalTo(expected));
+    }
+
+    @Test
+    public void getImageIdsForGivenIdOfActiveImageThenReturnsId() {
+        final Image mockImageNamedFoo = mock(Image.class);
+        final String imageId = "cfd083b4-2422-4c5f-bf61-d975709375ab";
+        when(mockImageNamedFoo.getId()).thenReturn(imageId);
+        when(mockImageNamedFoo.getName()).thenReturn("Foo");
+        when(mockImageNamedFoo.getStatus()).thenReturn(Image.Status.ACTIVE);
+        final ImageService mockIS = mock(ImageService.class);
+        when(mockIS.listAll(anyMapOf(String.class, String.class))).thenReturn(Collections.EMPTY_LIST);
+        when(mockIS.get(imageId)).thenReturn(mockImageNamedFoo);
+        final OSClient mockClient = mock(OSClient.class);
+        when(mockClient.images()).thenReturn(mockIS);
+        final ArrayList<String> expected = new ArrayList<>(Arrays.asList(mockImageNamedFoo.getId()));
+
+        final Openstack instance = new Openstack(mockClient);
+        final List<String> actual = instance.getImageIdsFor(imageId);
+
+        verify(mockIS).listAll(anyMapOf(String.class, String.class));
+        verify(mockIS).get(imageId);
+        verifyNoMoreInteractions(mockIS);
+        assertThat(new ArrayList<>(actual), equalTo(expected));
+    }
+
+    @Test
+    public void getVolumeSnapshotIdsForGivenNameThenReturnsMatchingVolumeSnapshotIdsSortedByAge() {
+        final VolumeSnapshot mockVolumeSnapshotNamedFoo = mock(VolumeSnapshot.class);
+        when(mockVolumeSnapshotNamedFoo.getId()).thenReturn("mockVolumeSnapshotNamedFooId");
+        when(mockVolumeSnapshotNamedFoo.getName()).thenReturn("Foo");
+        when(mockVolumeSnapshotNamedFoo.getStatus()).thenReturn(Volume.Status.AVAILABLE);
+        final VolumeSnapshot mockVolumeSnapshotNamedBar1 = mock(VolumeSnapshot.class);
+        when(mockVolumeSnapshotNamedBar1.getId()).thenReturn("mockVolumeSnapshotNamedBar1Id");
+        when(mockVolumeSnapshotNamedBar1.getName()).thenReturn("Bar");
+        when(mockVolumeSnapshotNamedBar1.getCreated()).thenReturn(new Date(11111));
+        when(mockVolumeSnapshotNamedBar1.getStatus()).thenReturn(Volume.Status.AVAILABLE);
+        final VolumeSnapshot mockVolumeSnapshotNamedBar2 = mock(VolumeSnapshot.class);
+        when(mockVolumeSnapshotNamedBar2.getId()).thenReturn("mockVolumeSnapshotNamedBar2Id");
+        when(mockVolumeSnapshotNamedBar2.getName()).thenReturn("Bar");
+        when(mockVolumeSnapshotNamedBar2.getCreated()).thenReturn(new Date(10000));
+        when(mockVolumeSnapshotNamedBar2.getStatus()).thenReturn(Volume.Status.AVAILABLE);
+        final VolumeSnapshot mockVolumeSnapshotNamedBar3 = mock(VolumeSnapshot.class);
+        when(mockVolumeSnapshotNamedBar3.getId()).thenReturn("mockVolumeSnapshotNamedBar3Id");
+        when(mockVolumeSnapshotNamedBar3.getName()).thenReturn("Bar");
+        when(mockVolumeSnapshotNamedBar3.getCreated()).thenReturn(new Date(11110));
+        when(mockVolumeSnapshotNamedBar3.getStatus()).thenReturn(Volume.Status.AVAILABLE);
+        final BlockVolumeSnapshotService mockBVSS = mock(BlockVolumeSnapshotService.class);
+        final List volumeSnapshots = Arrays.asList(mockVolumeSnapshotNamedFoo, mockVolumeSnapshotNamedBar1,
+                mockVolumeSnapshotNamedBar2, mockVolumeSnapshotNamedBar3);
+        when(mockBVSS.list()).thenReturn(volumeSnapshots);
+        final OSClient mockClient = mock(OSClient.class, RETURNS_DEEP_STUBS);
+        when(mockClient.blockStorage().snapshots()).thenReturn(mockBVSS);
+        final ArrayList<String> expected = new ArrayList<>(Arrays.asList("mockVolumeSnapshotNamedBar2Id",
+                "mockVolumeSnapshotNamedBar3Id", "mockVolumeSnapshotNamedBar1Id"));
+
+        final Openstack instance = new Openstack(mockClient);
+        final List<String> actual = instance.getVolumeSnapshotIdsFor("Bar");
+
+        final Map<String, String> expectedFilteringParams = new HashMap<>(2);
+        expectedFilteringParams.put("name", "Bar");
+        expectedFilteringParams.put("status", "active");
+        verify(mockBVSS).list();
+        verifyNoMoreInteractions(mockBVSS);
+        assertThat(new ArrayList<>(actual), equalTo(expected));
+    }
+
+    @Test
+    public void getVolumeSnapshotIdsForGivenUnknownThenReturnsEmpty() {
+        final VolumeSnapshot mockVolumeSnapshotNamedFoo = mock(VolumeSnapshot.class);
+        when(mockVolumeSnapshotNamedFoo.getId()).thenReturn("mockVolumeSnapshotNamedFooId");
+        when(mockVolumeSnapshotNamedFoo.getName()).thenReturn("Foo");
+        when(mockVolumeSnapshotNamedFoo.getStatus()).thenReturn(Volume.Status.AVAILABLE);
+        final VolumeSnapshot mockVolumeSnapshotNamedBar1 = mock(VolumeSnapshot.class);
+        when(mockVolumeSnapshotNamedBar1.getId()).thenReturn("mockVolumeSnapshotNamedBar1Id");
+        when(mockVolumeSnapshotNamedBar1.getName()).thenReturn("Bar");
+        when(mockVolumeSnapshotNamedBar1.getCreated()).thenReturn(new Date(11111));
+        when(mockVolumeSnapshotNamedBar1.getStatus()).thenReturn(Volume.Status.AVAILABLE);
+        final VolumeSnapshot mockVolumeSnapshotNamedBar2 = mock(VolumeSnapshot.class);
+        when(mockVolumeSnapshotNamedBar2.getId()).thenReturn("mockVolumeSnapshotNamedBar2Id");
+        when(mockVolumeSnapshotNamedBar2.getName()).thenReturn("Bar");
+        when(mockVolumeSnapshotNamedBar2.getCreated()).thenReturn(new Date(10000));
+        when(mockVolumeSnapshotNamedBar2.getStatus()).thenReturn(Volume.Status.AVAILABLE);
+        final VolumeSnapshot mockVolumeSnapshotNamedBar3 = mock(VolumeSnapshot.class);
+        when(mockVolumeSnapshotNamedBar3.getId()).thenReturn("mockVolumeSnapshotNamedBar3Id");
+        when(mockVolumeSnapshotNamedBar3.getName()).thenReturn("Bar");
+        when(mockVolumeSnapshotNamedBar3.getCreated()).thenReturn(new Date(11110));
+        when(mockVolumeSnapshotNamedBar3.getStatus()).thenReturn(Volume.Status.AVAILABLE);
+        final BlockVolumeSnapshotService mockBVSS = mock(BlockVolumeSnapshotService.class);
+        final List volumeSnapshots = Arrays.asList(mockVolumeSnapshotNamedFoo, mockVolumeSnapshotNamedBar1,
+                mockVolumeSnapshotNamedBar2, mockVolumeSnapshotNamedBar3);
+        when(mockBVSS.list()).thenReturn(volumeSnapshots);
+        final OSClient mockClient = mock(OSClient.class, RETURNS_DEEP_STUBS);
+        when(mockClient.blockStorage().snapshots()).thenReturn(mockBVSS);
+        final ArrayList<String> expected = new ArrayList<>();
+
+        final Openstack instance = new Openstack(mockClient);
+        final List<String> actual = instance.getVolumeSnapshotIdsFor("NameNotFound");
+
+        verify(mockBVSS).list();
+        verifyNoMoreInteractions(mockBVSS);
+        assertThat(new ArrayList<>(actual), equalTo(expected));
+    }
+
+    @Test
+    public void getVolumeSnapshotIdsForGivenIdOfActiveVolumeSnapshotThenReturnsId() {
+        final VolumeSnapshot mockVolumeSnapshotNamedFoo = mock(VolumeSnapshot.class);
+        final String volumeSnapshotId = "cfd083b4-2422-4c5f-bf61-d975709375ab";
+        when(mockVolumeSnapshotNamedFoo.getId()).thenReturn(volumeSnapshotId);
+        when(mockVolumeSnapshotNamedFoo.getName()).thenReturn("Foo");
+        when(mockVolumeSnapshotNamedFoo.getStatus()).thenReturn(Volume.Status.AVAILABLE);
+        final VolumeSnapshot mockVolumeSnapshotNamedBar1 = mock(VolumeSnapshot.class);
+        when(mockVolumeSnapshotNamedBar1.getId()).thenReturn("mockVolumeSnapshotNamedBar1Id");
+        when(mockVolumeSnapshotNamedBar1.getName()).thenReturn("Bar");
+        when(mockVolumeSnapshotNamedBar1.getCreated()).thenReturn(new Date(11111));
+        when(mockVolumeSnapshotNamedBar1.getStatus()).thenReturn(Volume.Status.AVAILABLE);
+        final VolumeSnapshot mockVolumeSnapshotNamedBar2 = mock(VolumeSnapshot.class);
+        when(mockVolumeSnapshotNamedBar2.getId()).thenReturn("mockVolumeSnapshotNamedBar2Id");
+        when(mockVolumeSnapshotNamedBar2.getName()).thenReturn("Bar");
+        when(mockVolumeSnapshotNamedBar2.getCreated()).thenReturn(new Date(10000));
+        when(mockVolumeSnapshotNamedBar2.getStatus()).thenReturn(Volume.Status.AVAILABLE);
+        final VolumeSnapshot mockVolumeSnapshotNamedBar3 = mock(VolumeSnapshot.class);
+        when(mockVolumeSnapshotNamedBar3.getId()).thenReturn("mockVolumeSnapshotNamedBar3Id");
+        when(mockVolumeSnapshotNamedBar3.getName()).thenReturn("Bar");
+        when(mockVolumeSnapshotNamedBar3.getCreated()).thenReturn(new Date(11110));
+        when(mockVolumeSnapshotNamedBar3.getStatus()).thenReturn(Volume.Status.AVAILABLE);
+        final List volumeSnapshots = Arrays.asList(mockVolumeSnapshotNamedFoo, mockVolumeSnapshotNamedBar1,
+                mockVolumeSnapshotNamedBar2, mockVolumeSnapshotNamedBar3);
+        final BlockVolumeSnapshotService mockBVSS = mock(BlockVolumeSnapshotService.class);
+        when(mockBVSS.list()).thenReturn(volumeSnapshots);
+        when(mockBVSS.get(volumeSnapshotId)).thenReturn(mockVolumeSnapshotNamedFoo);
+        final OSClient mockClient = mock(OSClient.class, RETURNS_DEEP_STUBS);
+        when(mockClient.blockStorage().snapshots()).thenReturn(mockBVSS);
+        final ArrayList<String> expected = new ArrayList<>(Arrays.asList(mockVolumeSnapshotNamedFoo.getId()));
+
+        final Openstack instance = new Openstack(mockClient);
+        final List<String> actual = instance.getVolumeSnapshotIdsFor(volumeSnapshotId);
+
+        verify(mockBVSS).list();
+        verify(mockBVSS).get(volumeSnapshotId);
+        verifyNoMoreInteractions(mockBVSS);
+        assertThat(new ArrayList<>(actual), equalTo(expected));
+    }
+
+    @Test
+    public void getAvailabilityZonesReturnsAZsSortedByName() {
+        final AvailabilityZone mockAZ1 = mock(AvailabilityZone.class);
+        when(mockAZ1.getZoneName()).thenReturn("Foo");
+        final AvailabilityZone mockAZ2 = mock(AvailabilityZone.class);
+        when(mockAZ2.getZoneName()).thenReturn("Bar");
+        final AvailabilityZone mockAZ3 = mock(AvailabilityZone.class);
+        when(mockAZ3.getZoneName()).thenReturn("Flibble");
+        final ZoneService mockZS = mock(ZoneService.class);
+        doReturn(Arrays.asList(mockAZ1, mockAZ2, mockAZ3)).when(mockZS).list();
+        final OSClient mockClient = mock(OSClient.class, RETURNS_DEEP_STUBS);
+        when(mockClient.compute().zones()).thenReturn(mockZS);
+        final ArrayList<AvailabilityZone> expected = new ArrayList<>(Arrays.asList(mockAZ2, mockAZ3, mockAZ1));
+
+        final Openstack instance = new Openstack(mockClient);
+        final List<? extends AvailabilityZone> actual = instance.getAvailabilityZones();
+
+        assertThat(new ArrayList<>(actual), equalTo(expected));
+    }
 
     public static final ClientResponseException CLIENT_RESPONSE_FIP_DISALLOWED = new ClientResponseException(
             "Policy doesn't allow compute_extension:floating_ip_pools to be performed",

--- a/src/test/java/jenkins/plugins/openstack/compute/slaveopts/BootSourceTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/slaveopts/BootSourceTest.java
@@ -1,0 +1,192 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.plugins.openstack.compute.slaveopts;
+
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+import jenkins.plugins.openstack.PluginTestRule;
+import jenkins.plugins.openstack.compute.internal.Openstack;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.openstack4j.api.OSClient;
+import org.openstack4j.api.image.ImageService;
+import org.openstack4j.model.image.Image;
+import org.openstack4j.model.storage.block.Volume;
+import org.openstack4j.model.storage.block.VolumeSnapshot;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static jenkins.plugins.openstack.compute.SlaveOptionsDescriptorTest.hasState;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class BootSourceTest {
+    private static final FormValidation VALIDATION_REQUIRED = FormValidation.error(hudson.util.Messages.FormValidation_ValidateRequired());
+
+    public @Rule PluginTestRule j = new PluginTestRule();
+
+    private BootSource.Image.Desc id;
+    private BootSource.VolumeSnapshot.Desc vsd;
+
+    @Before
+    public void before() {
+        id = (BootSource.Image.Desc) j.jenkins.getDescriptorOrDie(BootSource.Image.class);
+        vsd = (BootSource.VolumeSnapshot.Desc) j.jenkins.getDescriptorOrDie(BootSource.VolumeSnapshot.class);
+    }
+
+    @Test
+    public void doFillImageNameItemsPopulatesImageNamesNotIds() {
+        Image image = mock(Image.class);
+        when(image.getId()).thenReturn("image-id");
+        final String imageName = "image-name";
+        when(image.getName()).thenReturn(imageName);
+
+        Openstack os = j.fakeOpenstackFactory();
+        doReturn(Collections.singletonMap(imageName, Collections.singletonList(image))).when(os).getImages();
+
+        ListBoxModel list = id.doFillNameItems("", "OSurl", "OSid", "OSpwd", "OSzone");
+        assertEquals(2, list.size());
+        assertEquals("First menu entry is 'nothing selected'", "", list.get(0).value);
+        ListBoxModel.Option item = list.get(1);
+        assertEquals("menu item name", imageName, item.name);
+        assertEquals("menu item value", imageName, item.value);
+    }
+
+    @Test
+    public void doFillSnapshotNameItemsPopulatesVolumeSnapshotNames() {
+        VolumeSnapshot volumeSnapshot = mock(VolumeSnapshot.class);
+        when(volumeSnapshot.getId()).thenReturn("vs-id");
+        when(volumeSnapshot.getName()).thenReturn("vs-name");
+        when(volumeSnapshot.getStatus()).thenReturn(Volume.Status.AVAILABLE);
+        final Collection<VolumeSnapshot> justVolumeSnapshot = Collections.singletonList(volumeSnapshot);
+
+        Openstack os = j.fakeOpenstackFactory();
+        when(os.getVolumeSnapshots()).thenReturn(Collections.singletonMap("vs-name", justVolumeSnapshot));
+
+        ListBoxModel list = vsd.doFillNameItems("existing-vs-name", "OSurl", "OSid", "OSpwd", "OSzone");
+        assertEquals(3, list.size());
+        assertEquals("First menu entry is 'nothing selected'", "", list.get(0).value);
+        assertEquals("Second menu entry is the VS OpenStack can see", "vs-name", list.get(1).name);
+        assertEquals("Second menu entry is the VS OpenStack can see", "vs-name", list.get(1).value);
+        assertEquals("Third menu entry is the existing value", "existing-vs-name", list.get(2).name);
+        assertEquals("Third menu entry is the existing value", "existing-vs-name", list.get(2).value);
+    }
+
+    @Test @Issue("JENKINS-29993")
+    public void doFillImageIdItemsAcceptsNullAsImageName() {
+        Image image = mock(Image.class);
+        when(image.getId()).thenReturn("image-id");
+        when(image.getName()).thenReturn(null);
+
+        OSClient osClient = mock(OSClient.class);
+        ImageService imageService = mock(ImageService.class);
+        when(osClient.images()).thenReturn(imageService);
+        doReturn(Collections.singletonList(image)).when(imageService).listAll();
+
+        j.fakeOpenstackFactory(new Openstack(osClient));
+
+        ListBoxModel list = id.doFillNameItems("", "OSurl", "OSid", "OSpwd", "OSzone");
+        assertThat(list.get(0).name, list, Matchers.<ListBoxModel.Option>iterableWithSize(2));
+        assertEquals(2, list.size());
+        ListBoxModel.Option item = list.get(1);
+        assertEquals("image-id", item.name);
+        assertEquals("image-id", item.value);
+
+        verify(imageService).listAll();
+        verifyNoMoreInteractions(imageService);
+    }
+
+    @Test
+    public void doCheckImageIdWhenNoValueSet() throws Exception {
+        final String urlC, urlT, idC, idT, credC, credT, zoneC, zoneT;
+        urlC= urlT= idC= idT= credC= credT= zoneC= zoneT= "dummy";
+
+        final FormValidation actual = id.doCheckName("", urlC, urlT, idC, idT, credC, credT, zoneC, zoneT);
+        assertThat(actual, hasState(VALIDATION_REQUIRED));
+    }
+
+    @Test
+    public void doCheckImageIdWhenImageIsNotFoundInOpenstack() throws Exception {
+        final String urlC, urlT, idC, idT, credC, credT, zoneC, zoneT;
+        urlC= urlT= idC= idT= credC= credT= zoneC= zoneT= "dummy";
+        final Openstack os = mock(Openstack.class);
+        final List<String> noIDs = Collections.emptyList();
+        when(os.getImageIdsFor("imageNotFound")).thenReturn(noIDs);
+        j.fakeOpenstackFactory(os);
+        final FormValidation expected = FormValidation.error("Not found");
+
+        final FormValidation actual = id.doCheckName("imageNotFound", urlC, urlT, idC, idT, credC, credT, zoneC, zoneT);
+        assertThat(actual, hasState(expected));
+    }
+
+    @Test
+    public void doCheckImageIdWhenOneImageIsFound() throws Exception {
+        final String urlC, urlT, idC, idT, credC, credT, zoneC, zoneT;
+        urlC= urlT= idC= idT= credC= credT= zoneC= zoneT= "dummy";
+        final Openstack os = mock(Openstack.class);
+        when(os.getImageIdsFor("imageFound")).thenReturn(Collections.singletonList("imageFoundId"));
+        j.fakeOpenstackFactory(os);
+        final FormValidation expected = FormValidation.ok();
+
+        final FormValidation actual = id.doCheckName("imageFound", urlC, urlT, idC, idT, credC, credT, zoneC, zoneT);
+        assertThat(actual, hasState(expected));
+    }
+
+    @Test
+    public void doCheckImageIdWhenMultipleImagesAreFoundForTheName() throws Exception {
+        final String urlC, urlT, idC, idT, credC, credT, zoneC, zoneT;
+        urlC= urlT= idC= idT= credC= credT= zoneC= zoneT= "dummy";
+        final Openstack os = mock(Openstack.class);
+        when(os.getImageIdsFor("imageAmbiguous")).thenReturn(Arrays.asList("imageAmbiguousId1", "imageAmbiguousId2"));
+        j.fakeOpenstackFactory(os);
+        final FormValidation expected = FormValidation.warning("Multiple matching results");
+
+        final FormValidation actual = id.doCheckName("imageAmbiguous", urlC, urlT, idC, idT, credC, credT, zoneC, zoneT);
+        assertThat("imageAmbiguous", actual, hasState(expected));
+    }
+
+    @Test
+    public void doCheckImageIdWhenOneVolumeSnapshotIsFound() throws Exception {
+        final String urlC, urlT, idC, idT, credC, credT, zoneC, zoneT;
+        urlC= urlT= idC= idT= credC= credT= zoneC= zoneT= "dummy";
+        final Openstack os = mock(Openstack.class);
+        when(os.getVolumeSnapshotIdsFor("vsFound")).thenReturn(Collections.singletonList("vsFoundId"));
+        j.fakeOpenstackFactory(os);
+        final FormValidation expected = FormValidation.ok();
+
+        final FormValidation actual = vsd.doCheckName("vsFound", urlC, urlT, idC, idT, credC, credT, zoneC, zoneT);
+        assertThat("vsFound", actual, hasState(expected));
+    }
+}


### PR DESCRIPTION
I want to provide the user with the ability to define a VM in terms of a "Volume Snapshot", whereas at present we are limited to only allowing users to base their VMs on an "Image".
i.e. implement https://issues.jenkins-ci.org/browse/JENKINS-41126

These changes include:
 - Can now start instances from a VolumeSnapshot; we are no longer limited to Images.
 - Improved validation of imageId field in the configuration WebUI.
 - If an image name matches multiple ids then we'll use the most-recent (and warn).
 - Improved validation of the availability zone  field in the configuration WebUI (if it's ambiguous, we'll warn)