### PR TITLE
WIP | Fix for JENKINS-42207

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsCloud.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsCloud.java
@@ -142,14 +142,15 @@ public class JCloudsCloud extends Cloud implements SlaveOptions.Holder {
         },
         JNLP {
             @Override
-            public ComputerLauncher createLauncher(@Nonnull JCloudsSlave slave) {
+            public ComputerLauncher createLauncher(@Nonnull JCloudsSlave slave) throws IOException {
+                Jenkins.getActiveInstance().addNode(slave);
                 return new JNLPLauncher();
             }
 
             @Override
             public boolean isReady(@Nonnull JCloudsSlave slave) {
                 // The address might not be visible at all so let's just wait for connection.
-                return true;
+                return slave.getChannel() != null;
             }
         };
 


### PR DESCRIPTION
This pull includes a workaround for [JENKINS-42207](https://issues.jenkins-ci.org/browse/JENKINS-42207). 

It is very much a Work In Progress and I'm unsure if the workaround is even a viable long term fix for your project. I have also not made any attempt to update the unit tests. I'll likely need some help and guidance in this area if you'd like the pull to be more thorough.

Mainly, I just wanted to share some of what I've discovered to hopefully shed some light on the bug report I submitted.

To recap, the OpenStack plugin (2.17+) fails to wait for JNLP connections. It currently
reports isReady immediately, before the provisioned JNLP node has had
a chance to establish its connection with the Jenkins master.

This can result in the OpenStack plugin continually provisioning JNLP
nodes until a JNLP agent establishes a connection to master and reduces
the `excessWorkload` to 0, the OpenStack tenant runs out of compute
resources, or the global instance cap is reached -whichever comes first.

To fix this I've done two things:

1. JCloudsCloud::JNLP::isReady now reports based on the status of the
slave's communication channel.

   Similar to the SSH path, the OpenStack plugin now holds off on
   provisioning new nodes until JNLP agent has established its connection.

2. Add the JNLP slave to Jenkin's list of active connections

   Without this step, if JCloudsCloud::JNLP::isReady returns false and the
   JNLP agent has yet to establish a connection, the JCloudsCleanupThread
   will immediately reclaim the JNLP node in `JCloudsCleanupThread::destroyServersOutOfScope`
   because the unconnected JNLP node is out of scope i.e. the node is not
   found in the list of active nodes...thus preventing the node from ever
   provisioning.

   Adding the JNLP node to the list of active nodes prevents the
   JDCLoudsCleanup thread from reclaiming the node immediately,
   but I'm unsure if it's the right approach.

   It's modeled after the `JCloudsCloud::doProvision` step for manually
   provisioning nodes by clicking the button in the computer list. This
   manual step always adds the slave, regardless of type, so I figure this
   is safe from a conceptual point of view, but I'm unsure if
   `JDCloudsCloud::JNLP::createLauncher` is the most appropriate place for
   this action to occur. I'm also unsure why the SSH agent doesn't also
   require this step.

The end result, is that the OpenStack plugin no longer provisions excess
nodes, and now appropriately waits for JNLP nodes to connect.

I've tested the pull in our OpenStack environment and verified now, only a single JNLP nodes spawns from Pipeline projects.

My two biggest questions are:

1. Is the change to `isReady` the correct approach to take?
    * It certainly prevents multiple nodes from continually launching and chewing up resources
    * It's now more similar to the SSH path
    * But I'm unsure if this has unintended consequences ... how do JNLP nodes timeout?
    * Returning `true` may be sufficient if we can reduce the `excessWorkload` to 0 to keep new nodes from being provisioned by `JCloudsCloud::provision` ... maybe there's a better way?
2. Is adding the JNLP slave to the list of active instances the correct approach?
    * It seems no worse than what happens when you manually launch a node --this is what `JCloudsCloud::doProvision` does
    * SSH nodes don't appear to have this problem, how are they being added to the list of active nodes?

If there's any way I can be of further help, let me know.

Regards,
Ryan
