### PR TITLE
Pipeline step for agentless node provisioning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.19</version>
+        <version>2.21</version>
     </parent>
 
     <artifactId>openstack-cloud</artifactId>
@@ -14,8 +14,8 @@
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Openstack+Cloud+Plugin</url>
 
     <properties>
-        <jenkins.version>1.609.1</jenkins.version>
-        <jenkins-test-harness.version>2.18</jenkins-test-harness.version>
+        <jenkins.version>1.642.3</jenkins.version>
+        <jenkins-test-harness.version>2.21</jenkins-test-harness.version>
         <java.level>7</java.level>
         <concurrency>2</concurrency>
         <surefire.useFile>false</surefire.useFile>
@@ -91,6 +91,11 @@
             <artifactId>resource-disposer</artifactId>
             <version>0.5</version>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <version>2.8</version>
+        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>
@@ -103,6 +108,31 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.9.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <version>2.25</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-support</artifactId>
+            <classifier>tests</classifier>
+            <version>2.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <version>2.9</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <artifactId>workflow-basic-steps</artifactId>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <version>2.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/jenkins/plugins/openstack/compute/OpenStackStep.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/OpenStackStep.java
@@ -1,0 +1,145 @@
+package jenkins.plugins.openstack.compute;
+
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.slaves.Cloud;
+import hudson.util.ListBoxModel;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.steps.*;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * Returns the a POJO, Wrapping a org.openstack4j.model.compute.Server object.
+ *
+ * Usage is as:
+ *
+ * <pre>
+ * node {
+ *     def x = openstack cloud: 'mitaka', template: 'CentOS-7'
+ * }
+ * </pre>
+ *
+ */
+public class OpenStackStep extends Step {
+
+    private @Nonnull String cloud = "";
+    private @Nonnull String template = "";
+    private @Nonnull String scope = "run";
+    private @Nonnull String run = "";
+
+    @DataBoundConstructor
+    public OpenStackStep() {
+    }
+
+    @DataBoundSetter
+    public void setCloud(String cloud) {
+        this.cloud = cloud;
+    }
+
+    @DataBoundSetter
+    public void settemplate(String template) {
+        this.template = template;
+    }
+
+    @DataBoundSetter
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
+
+    public String getCloud() {
+        return cloud;
+    }
+
+    public String getTemplate() {
+        return template;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        this.run = context.get(Run.class).getFullDisplayName().replace(" #", ":");
+        return new OpenStackStep.Execution( this, context);
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends StepDescriptor {
+
+        @Override
+        public String getFunctionName() {
+            return "openstackMachine";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Cloud instances provisioning";
+        }
+
+        public ListBoxModel doFillCloudItems() {
+            ListBoxModel r = new ListBoxModel();
+            r.add("", "");
+            Jenkins.CloudList clouds = jenkins.model.Jenkins.getActiveInstance().clouds;
+            for (Cloud cloud: clouds) {
+                if (cloud instanceof JCloudsCloud) {
+                    r.add(cloud.getDisplayName(), cloud.getDisplayName());
+                }
+            }
+            return r;
+        }
+
+        public ListBoxModel doFillTemplateItems(@QueryParameter String cloud) {
+            cloud = Util.fixEmpty(cloud);
+            ListBoxModel r = new ListBoxModel();
+            for (Cloud cl : jenkins.model.Jenkins.getActiveInstance().clouds) {
+                if (cl.getDisplayName().equals(cloud) && (cl instanceof JCloudsCloud)) {
+                    for (JCloudsSlaveTemplate template : ((JCloudsCloud) cl).getTemplates()) {
+                       r.add(template.name);
+                    }
+                }
+            }
+            return r;
+        }
+
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return Collections.singleton(TaskListener.class);
+        }
+
+    }
+
+    public static class Execution extends SynchronousNonBlockingStepExecution<SimplifiedServer> {
+        private final String cloud;
+        private final String template;
+        private final String scope;
+
+
+        Execution(OpenStackStep step, StepContext context) {
+            super(context);
+            this.cloud = step.cloud;
+            this.template = step.template;
+            if ("run".equals(step.scope)) {
+                this.scope = "run:" + step.run;
+            } else if ("unlimited".equals(step.scope)) {
+                this.scope = "unlimited:run";
+            } else {
+                this.scope = step.scope;
+            }
+        }
+
+        @Override
+        protected SimplifiedServer run() throws Exception {
+            return new SimplifiedServer(this.cloud, this.template, this.scope);
+        }
+    }
+}

--- a/src/main/java/jenkins/plugins/openstack/compute/ServerScope.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/ServerScope.java
@@ -57,6 +57,9 @@ public abstract class ServerScope {
     protected final @Nonnull String specifier;
 
     public static ServerScope parse(String scope) throws IllegalArgumentException {
+        if (scope.startsWith("unlimited")) {
+            return Unlimited.getInstance();
+        }
         String[] chunks = scope.trim().split(":", 2);
         if (chunks.length != 2) throw new IllegalArgumentException("Invalid scope: " + scope);
         if ("node".equals(chunks[0])) {
@@ -249,6 +252,34 @@ public abstract class ServerScope {
         protected boolean _equals(ServerScope o) {
             Time that = (Time) o;
             return aliveUntil == that.aliveUntil;
+        }
+    }
+
+    public static final class Unlimited extends ServerScope {
+
+        private static Unlimited INSTANCE = new Unlimited();
+
+        private Unlimited() {
+            super("unlimited", "unlimited:run");
+        }
+
+        public static Unlimited getInstance() {
+            return INSTANCE;
+        }
+
+        @Override
+        public boolean isOutOfScope() {
+            return false;
+        }
+
+        @Override
+        public String getValue() {
+            return "unlimited:run";
+        }
+
+        @Override
+        protected boolean _equals(ServerScope o) {
+            return false;
         }
     }
 }

--- a/src/main/java/jenkins/plugins/openstack/compute/SimplifiedServer.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/SimplifiedServer.java
@@ -1,0 +1,75 @@
+package jenkins.plugins.openstack.compute;
+
+import jenkins.plugins.openstack.compute.internal.DestroyMachine;
+import jenkins.plugins.openstack.compute.internal.Openstack;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+import org.openstack4j.model.compute.Server;
+
+import java.io.Serializable;
+
+public class SimplifiedServer implements Serializable{
+
+    private Server srv = null;
+    private String cloud = "";
+    private String template = "";
+    private String scope = "";
+
+    public SimplifiedServer(String cloud, String template, String scope) {
+        this.template = template;
+        this.cloud = cloud;
+        this.scope = scope;
+
+        ServerScope serverscope = ServerScope.parse(scope);
+        JCloudsCloud jcl = JCloudsCloud.getByName(cloud);
+        JCloudsSlaveTemplate t = jcl.getTemplate(template);
+        if (t != null) {
+            this.srv = t.provision(jcl, serverscope);
+        } else {
+            throw new IllegalArgumentException("Invalid template: " + template);
+        }
+    }
+
+    @Whitelisted
+    public void destroy() {
+        if (srv != null) {
+            DestroyMachine dm = new DestroyMachine(this.cloud, srv.getId());
+            dm.dispose();
+            srv = null;
+        } else {
+            //Cant destroy what isn't created
+        }
+    }
+
+    @Whitelisted
+    public String getAddress() {
+        String addr = "";
+        if (srv != null) {
+            try {
+                addr = Openstack.getPublicAddress(srv);
+            } catch (NullPointerException npe) {
+                //Seems the machine doesnt have any address (related to boot-up?)
+            }
+        } else {
+            //No IPs from unprovisioned servers
+        }
+        return addr;
+    }
+
+    @Whitelisted
+    public String getStatus() {
+        if (srv != null) {
+            return srv.getStatus().name();
+        } else {
+            return null;
+        }
+    }
+
+    @Whitelisted
+    public String getId() {
+        if (srv != null) {
+           return srv.getId();
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/resources/jenkins/plugins/openstack/compute/OpenStackStep/config.jelly
+++ b/src/main/resources/jenkins/plugins/openstack/compute/OpenStackStep/config.jelly
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry field="cloud" title="Openstack cloud name">
+        <f:select/>
+    </f:entry>
+    <f:entry field="template" title="Template name">
+        <f:select/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/jenkins/plugins/openstack/compute/OpenStackStep/help.html
+++ b/src/main/resources/jenkins/plugins/openstack/compute/OpenStackStep/help.html
@@ -1,0 +1,18 @@
+<div>
+    Creates an Openstack <code>Instance</code> object, from an already globally defined cloud name and label without registering it as a Jenkins agent. </br>
+    This step has a third optional String parameter, named scope, reflecting the booted Server scope, with possible values from:</br>
+    <dl>
+        <dt><code>run</code></dt>
+        <dd>The booted Instance will be kept alive whilst the current run is kicking. This is the default mode if no scope is defined.
+        </dd>
+        <dt><code>run:JOB_NAME:BUILD_NUMBER</code></dt>
+        <dd>The booted Instance will be kept alive whilst the run defined with JOB_NAME:RUN_ID is kicking.
+        </dd>
+        <!-- <dt><code>time:DATE</code></dt>
+        <dd>The booted Instance will be kept alive until DATE (formatted as yyyy-MM-dd HH:mm:ss).
+        </dd> -->
+        <dt><code>unlimited</code></dt>
+        <dd>The booted Instance will be kept alive forever. Mind the possible resources extarvation at the Openstack provider!
+        </dd>
+    </dl>
+</div>

--- a/src/test/java/jenkins/plugins/openstack/PluginTestRule.java
+++ b/src/test/java/jenkins/plugins/openstack/PluginTestRule.java
@@ -1,10 +1,7 @@
 package jenkins.plugins.openstack;
 
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.RETURNS_SMART_NULLS;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.io.File;
 import java.io.FilterOutputStream;
@@ -312,7 +309,7 @@ public final class PluginTestRule extends JenkinsRule {
     }
 
     public Openstack fakeOpenstackFactory() {
-        return fakeOpenstackFactory(mock(Openstack.class, RETURNS_SMART_NULLS));
+        return fakeOpenstackFactory(mock(Openstack.class, withSettings().defaultAnswer(RETURNS_SMART_NULLS).serializable()));
     }
 
     @SuppressWarnings("deprecation")
@@ -330,7 +327,7 @@ public final class PluginTestRule extends JenkinsRule {
 
     @SuppressWarnings("deprecation")
     public Openstack.FactoryEP mockOpenstackFactory() {
-        Openstack.FactoryEP factory = mock(Openstack.FactoryEP.class);
+        Openstack.FactoryEP factory = mock(Openstack.FactoryEP.class, withSettings().serializable());
         ExtensionList<Openstack.FactoryEP> lookup = ExtensionList.lookup(Openstack.FactoryEP.class);
         lookup.clear();
         lookup.add(factory);
@@ -351,9 +348,10 @@ public final class PluginTestRule extends JenkinsRule {
         private final Map<String, String> metadata = new HashMap<>();
 
         public MockServerBuilder() {
-            server = mock(Server.class);
+            server = mock(Server.class, withSettings().serializable());
             when(server.getId()).thenReturn(UUID.randomUUID().toString());
             when(server.getAddresses()).thenReturn(new NovaAddresses());
+            when(server.getStatus()).thenReturn(Server.Status.ACTIVE);
             when(server.getMetadata()).thenReturn(metadata);
             metadata.put("jenkins-instance", jenkins.getRootUrl()); // Mark the slave as ours
         }
@@ -364,7 +362,7 @@ public final class PluginTestRule extends JenkinsRule {
         }
 
         public MockServerBuilder floatingIp(String ip) {
-            NovaAddress addr = mock(NovaAddress.class);
+            NovaAddress addr = mock(NovaAddress.class, withSettings().serializable());
             when(addr.getType()).thenReturn("floating");
             when(addr.getAddr()).thenReturn(ip);
 
@@ -444,7 +442,7 @@ public final class PluginTestRule extends JenkinsRule {
                 .build()
         ;
 
-        private final transient Openstack os = mock(Openstack.class, RETURNS_SMART_NULLS);
+        private final transient Openstack os = mock(Openstack.class, withSettings().defaultAnswer(RETURNS_SMART_NULLS).serializable());
 
         public MockJCloudsCloud(JCloudsSlaveTemplate... templates) {
             this(DEFAULTS, templates);

--- a/src/test/java/jenkins/plugins/openstack/compute/OpenstackStepTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/OpenstackStepTest.java
@@ -1,0 +1,87 @@
+package jenkins.plugins.openstack.compute;
+
+import hudson.model.Result;
+import jenkins.plugins.openstack.PluginTestRule;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.*;
+
+public class OpenstackStepTest {
+
+    @Rule
+    public PluginTestRule j = new PluginTestRule();
+
+    @Before
+    public void setup () {
+        JCloudsCloud cloud = j.createCloudLaunchingDummySlaves("whatever");
+        j.jenkins.clouds.add(cloud);
+    }
+
+    @Test
+    public void boot() throws Exception {
+
+        WorkflowJob boot = j.jenkins.createProject(WorkflowJob.class, "boot");
+        boot.setDefinition(new CpsFlowDefinition(
+                                "def srv = openstackMachine cloud: 'openstack', template: 'template0' \n" +
+                                        "echo srv.getAddress() \n" +
+                                        "echo srv.id \n" +
+                                        "echo srv.status \n" +
+                                        "srv.destroy() \n" +
+                                        "assert srv.status == null \n" +
+                                        "assert srv.address == ''" , true));
+        WorkflowRun b = j.assertBuildStatusSuccess(boot.scheduleBuild2(0));
+        j.assertLogContains("42.42.42", b);
+        j.assertLogContains("ACTIVE", b);
+    }
+
+    @Test
+    public void bootUnmanaged() throws Exception {
+
+        WorkflowJob bootUnmanaged = j.jenkins.createProject(WorkflowJob.class, "boot Unmanaged");
+        bootUnmanaged.setDefinition(new CpsFlowDefinition(
+                "def srv = openstackMachine cloud: 'openstack', template: 'template0', scope: 'unlimited' \n" +
+                        "echo srv.address \n" +
+                        "srv.destroy()" , true));
+        WorkflowRun b = j.assertBuildStatusSuccess(bootUnmanaged.scheduleBuild2(0));
+        j.assertLogContains("42.42.42", b);
+    }
+
+    @Test
+    public void bootInvalidScope() throws Exception {
+
+        WorkflowJob bootInvalidScope = j.jenkins.createProject(WorkflowJob.class, "bootInvalidScope");
+        bootInvalidScope.setDefinition(new CpsFlowDefinition(
+                        " def srv = openstackMachine cloud: 'openstack', template: 'template0', scope: 'invalidScope' \n" +
+                        " echo 'shouldnt reach' " , true));
+        WorkflowRun b = j.assertBuildStatus(Result.FAILURE, bootInvalidScope.scheduleBuild2(0));
+        j.assertLogNotContains("shouldnt reach", b);
+        j.assertLogContains("Invalid scope", b);
+    }
+
+    @Test
+    public void bootInvalidTemplate() throws Exception {
+
+        WorkflowJob bootInvalidTEmplate = j.jenkins.createProject(WorkflowJob.class, "bootInvalidTEmplate");
+        bootInvalidTEmplate.setDefinition(new CpsFlowDefinition(
+                " def srv = openstackMachine cloud: 'openstack', template: 'OtherTemplate'\n" +
+                        " echo 'shouldnt reach' " , true));
+        WorkflowRun b = j.assertBuildStatus(Result.FAILURE, bootInvalidTEmplate.scheduleBuild2(0));
+        j.assertLogNotContains("shouldnt reach", b);
+        j.assertLogContains("Invalid template", b);
+    }
+
+    @Test
+    public void checkSerializableSimplifiedServer() throws Exception {
+
+        WorkflowJob bootSerializableCheck = j.jenkins.createProject(WorkflowJob.class, "bootSerializableCheck");
+        bootSerializableCheck.setDefinition(new CpsFlowDefinition(
+                " def srv = openstackMachine cloud: 'openstack', template: 'template0', scope: 'time:1970-01-01 00:00:00' \n" +
+                        "node ('master') { \n" +
+                        "  sh \"echo Instance IP: ${srv.address}\" \n" +
+                        "} \n" +
+                        "srv.destroy()", true));
+        WorkflowRun b = j.assertBuildStatusSuccess(bootSerializableCheck.scheduleBuild2(0));
+        j.assertLogContains("Instance IP: 42.42.42", b);
+    }
+}

--- a/src/test/java/jenkins/plugins/openstack/compute/ServerScopeTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/ServerScopeTest.java
@@ -1,5 +1,6 @@
 package jenkins.plugins.openstack.compute;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.*;
 
@@ -37,6 +38,11 @@ public class ServerScopeTest {
         ServerScope.Time time2 = (ServerScope.Time) ServerScope.parse(time.getValue());
         assertEquals("time:2017-01-11 14:09:25", time.getValue());
         assertEquals(time, time2);
+
+        ServerScope.Unlimited unlimited = (ServerScope.Unlimited) ServerScope.parse("unlimited:run");
+        assertEquals("unlimited:run", unlimited.getValue());
+        assertEquals(unlimited, ServerScope.parse(unlimited.getValue()));
+
     }
 
     @Test
@@ -78,5 +84,12 @@ public class ServerScopeTest {
         Thread.sleep(100);
         assertTrue(timedOut.isOutOfScope());
         assertThat(timedOut.getValue(), startsWith("time:20"));
+    }
+
+    @Test
+    public void unlimitedScope() throws Exception {
+        ServerScope.Unlimited alive = ServerScope.Unlimited.getInstance();
+        assertFalse(alive.isOutOfScope());
+        assertThat(alive.getValue(), equalTo("unlimited:run"));
     }
 }


### PR DESCRIPTION
this PR adds a openstack step, callable from within a pipeline.

With this syntax:
`def IP = openstack serverName:"OpenStackDev", template:"CentOS7"`

A node will be provisioned at the cloud named OpenStackDev, from the already defined template CentOS7. The step would return the node IP. The provisioned node won't be included as a Jenkins agent (and so, the JCloudsCleanupThread wont get rid of it) 

The snipplet generator allows to select both parameters from the globally defined ones. 

As a hacky solution, an empty/unlimited Scope is allowed so that JCloudsCleanupThread doesn't delete the provisioned node