### PR TITLE
Fixed getPublicAddress to getPublicAddressIpv4 to ensure the selected…

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlave.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlave.java
@@ -16,6 +16,8 @@ import org.jenkinsci.plugins.cloudstats.ProvisioningActivity;
 import org.jenkinsci.plugins.cloudstats.TrackedItem;
 import org.jenkinsci.plugins.resourcedisposer.AsyncResourceDisposer;
 import org.jenkinsci.plugins.resourcedisposer.Disposable;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.openstack4j.model.compute.Server;
 
 import javax.annotation.CheckForNull;
@@ -118,7 +120,8 @@ public class JCloudsSlave extends AbstractCloudSlave implements TrackedItem {
     /**
      * Get public IP address of the server.
      */
-    public @CheckForNull String getPublicAddressIpv4() {
+    @Restricted(NoExternalUse.class)
+    /*package*/ @CheckForNull String getPublicAddressIpv4() {
     	
         return Openstack.getPublicAddressIpv4(getOpenstack(cloudName).getServerById(nodeId));
     }

--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlave.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlave.java
@@ -112,7 +112,15 @@ public class JCloudsSlave extends AbstractCloudSlave implements TrackedItem {
      * Get public IP address of the server.
      */
     public @CheckForNull String getPublicAddress() {
+    	
         return Openstack.getPublicAddress(getOpenstack(cloudName).getServerById(nodeId));
+    }
+    /**
+     * Get public IP address of the server.
+     */
+    public @CheckForNull String getPublicAddressIpv4() {
+    	
+        return Openstack.getPublicAddressIpv4(getOpenstack(cloudName).getServerById(nodeId));
     }
 
     /**

--- a/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
@@ -420,6 +420,27 @@ public class Openstack {
      *
      * @return Floating IP, if there is none Fixed IP, null if there is none either.
      */
+    public static @CheckForNull Address getPublicAddressObject(@Nonnull Server server) {
+    	Address fixed = null;
+        for (List<? extends Address> addresses: server.getAddresses().getAddresses().values()) {
+            for (Address addr: addresses) {
+                if ("floating".equals(addr.getType())) {
+                    return addr;
+                }
+
+                fixed = addr;
+            }
+        }
+
+        // No floating IP found - use fixed
+        return fixed;
+    }
+    
+    /**
+     * Extract public address from server info.
+     *
+     * @return Floating IP, if there is none Fixed IP, null if there is none either.
+     */
     public static @CheckForNull String getPublicAddress(@Nonnull Server server) {
         String fixed = null;
         for (List<? extends Address> addresses: server.getAddresses().getAddresses().values()) {
@@ -436,6 +457,32 @@ public class Openstack {
         return fixed;
     }
 
+
+    /**
+     * Extract public address from server info.
+     *
+     * @return Floating IP, if there is none Fixed IP, null if there is none either.
+     */
+    public static @CheckForNull String getPublicAddressIpv4(@Nonnull Server server) {
+        String fixed = null;
+        for (List<? extends Address> addresses: server.getAddresses().getAddresses().values()) {
+            for (Address addr: addresses) {
+                if ("floating".equals(addr.getType())) {
+                    return addr.getAddr();
+                } else if (addr.getVersion()==4) {
+                	fixed = addr.getAddr();
+                }
+                
+
+                
+            }
+        }
+
+        // No floating IP found - use fixed
+        return fixed;
+    }
+
+    
     /**
      * @return true if succeeded.
      */


### PR DESCRIPTION
… address is IPV4.

Issue came up using OVH openstack which returns IPV6 address as last
address, yielding IPV6 address being returned and Socket connect test
failing.

A unit test could be added based on server descriptor return by OVH provider, but not sure this is very relevant.