### PR TITLE
Online help improvements.

### DIFF
--- a/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/help-endPointUrl.html
+++ b/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/help-endPointUrl.html
@@ -1,3 +1,23 @@
 <div>
   API endpoint URL for Keystone (also known as Identity service).
+  <ul>
+    <li>
+    The administrator for your OpenStack deployment should be able to provide this.
+    </li>
+    <li>
+      If you have an &quot;<tt>openrc</tt>&quot; file then this is the value of <tt>OS_AUTH_URL</tt>.
+    </li>
+    <li>
+      If you have a user-friendly web front end, you may find
+      this information under an "API" sub-heading.
+    <br/>
+      e.g. The &quot;Horizon&quot; Openstack Dashboard has this information
+      under Compute -&gt; Access &amp; Security -&gt; API Access -&gt; Identity.
+    </li>
+  </ul>
+  For example, an Openstack deployment using &quot;v2 authentication&quot; might have an endpoint of
+  <tt>https://some.host.name:5000/v2.0</tt>
+  <br/>
+  Similarly, an Openstack deployment using &quot;v3 authentication&quot; might have an endpoint of
+  <tt>https://some.other.host:5000/v3</tt><br/>
 </div>

--- a/src/main/resources/jenkins/plugins/openstack/compute/SlaveOptions/help-userDataId.jelly
+++ b/src/main/resources/jenkins/plugins/openstack/compute/SlaveOptions/help-userDataId.jelly
@@ -1,6 +1,20 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
   <div>
-    You can specify userdata via <a target="_blank" href="${app.rootUrl}configfiles/">Jenkins -> Manage Jenkins -> Managed Files -> Add New Config (OpenStack User Data)</a>.
+    <p>
+    Selects which (if any) user data is sent to the cloud-init process when the instance first boots up.
+    The cloud-init process typically auto-detects the format/syntax of the script from the first line.
+    <br/>
+    Hint: This is an effective (and recommended) method of passing JNLP connection information to the
+    newly-created instance.
+    </p>
+    <p>
+    Note: Before you can select a user data script, you will first need to define one.
+    You can add, remove and edit your user data scripts via
+    <a target="_blank" href="${app.rootUrl}configfiles/">
+    Jenkins -> Manage Jenkins -> Managed Files -> Add New Config (OpenStack User Data)
+    </a>.
+    See the help on that page for further details (including examples for JNLP).
+    </p>
   </div>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/openstack/compute/UserDataConfig/help-userData.jelly
+++ b/src/main/resources/jenkins/plugins/openstack/compute/UserDataConfig/help-userData.jelly
@@ -2,10 +2,6 @@
 <j:jelly xmlns:j="jelly:core">
   <div>
     <p>
-    Selects which (if any) user data is sent to the cloud-init process when the instance first boots up.
-    The cloud-init process typically auto-detects the format/syntax of the script from the first line.
-    </p>
-    <p>
     Before the userdata is sent to the OpenStack instance, the following values are injected and can be referenced within the userdata using $${VARIABLE_NAME} syntax:
     <dl>
       <!-- Descriptor not exposed for help files? -->


### PR DESCRIPTION
Help text for EndpointURL (.../JCloudsCloud/help-endPointUrl.html) now
explains how to find out what the URL is likely to be and provides
examples.
Help text for UserDataId (.../SlaveOptions/help-userDataId.jelly, the bit in
the template where the user selects which UserData script to use) now
explains why you need this.
Help text for UserData (.../UserDataConfig/help-userData.jelly, where the user
defines the UserData scripts for use in the templates) no longer says this is
where you select which script to use (this was a copy/paste error from when
the help was relocated).