### PR TITLE
Add a Jenkinsfile so https://ci.jenkins.io/ will build us.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,4 @@
+#!/usr/bin/env groovy
+
+/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
+buildPlugin()


### PR DESCRIPTION
As per advice from #jenkins irc channel, we need a "Jenkinsfile"
in order for the automatic builds to happen on the Jenkins CI.
Until that is done, we don't get automatic builds of pull requests.