### PR TITLE
Fix unit-tests that failed or are flakey

### DIFF
--- a/src/test/java/jenkins/plugins/openstack/pipeline/OpenstackMachineStepTest.java
+++ b/src/test/java/jenkins/plugins/openstack/pipeline/OpenstackMachineStepTest.java
@@ -101,7 +101,7 @@ public class OpenstackMachineStepTest {
         bootSerializableCheck.setDefinition(new CpsFlowDefinition(
                 " def srv = openstackMachine cloud: 'openstack', template: 'template0'\n" +
                         "node ('master') { \n" +
-                        "  sh \"echo Instance IP: ${srv.address}\" \n" +
+                        "  echo \"Instance IP: ${srv.address}\" \n" +
                         "} \n" +
                         "srv.destroy()", true));
         WorkflowRun b = j.assertBuildStatusSuccess(bootSerializableCheck.scheduleBuild2(0));


### PR DESCRIPTION
OpenstackMachineStepTest.checkSerializableSimplifiedServer fails on Windows.  Can't use a "sh" pipeline step when running on Windows.

JCloudsCloudTest.globalConfigMigrationFromV1 suffers from comparing multi-line strings which are sometimes unix-EOLs and sometimes Windows-EOLs when running on Windows.

ProvisioningTest did not account for Cloud Statistics data being updated asynchronously, or for AsyncResourceDisposer resources being disposed of asynchronously, so it would sometimes fail "at random".