### PR TITLE
[JENKINS-46541] Do not use expired login sessions

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsCloud.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsCloud.java
@@ -78,9 +78,6 @@ public class JCloudsCloud extends Cloud implements SlaveOptions.Holder {
     private transient @Deprecated Integer startTimeout;
     private transient @Deprecated Boolean floatingIps;
 
-    // Cache the instance between uses
-    private volatile transient @CheckForNull Openstack openstack;
-
     public static @Nonnull List<JCloudsCloud> getClouds() {
         List<JCloudsCloud> clouds = new ArrayList<>();
         for (Cloud c : Jenkins.getActiveInstance().clouds) {
@@ -379,15 +376,12 @@ public class JCloudsCloud extends Cloud implements SlaveOptions.Holder {
      */
     @Restricted(DoNotUse.class)
     public @Nonnull Openstack getOpenstack() {
-        Openstack os = openstack;
-        if (os == null) {
-            try {
-                os = openstack = Openstack.Factory.get(endPointUrl, identity, credential.getPlainText(), zone);
-            } catch (FormValidation ex) {
-                openstack = null;
-                LOGGER.log(Level.SEVERE, "Openstack credentials invalid", ex);
-                throw new RuntimeException("Openstack credentials invalid", ex);
-            }
+        final Openstack os;
+        try {
+            os = Openstack.Factory.get(endPointUrl, identity, credential.getPlainText(), zone);
+        } catch (FormValidation ex) {
+            LOGGER.log(Level.SEVERE, "Openstack credentials invalid", ex);
+            throw new RuntimeException("Openstack credentials invalid", ex);
         }
         return os;
     }

--- a/src/test/java/jenkins/plugins/openstack/compute/SlaveOptionsDescriptorTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/SlaveOptionsDescriptorTest.java
@@ -9,11 +9,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import hudson.util.ListBoxModel;
 import jenkins.plugins.openstack.PluginTestRule;
@@ -34,6 +36,7 @@ import org.openstack4j.openstack.image.domain.GlanceImage;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
@@ -150,7 +153,10 @@ public class SlaveOptionsDescriptorTest {
         image.setId("image-id");
         image.setName(null);
 
-        OSClient osClient = mock(OSClient.class);
+        OSClient.OSClientV2 osClient = mock(OSClient.OSClientV2.class, withSettings().defaultAnswer(RETURNS_DEEP_STUBS));
+        final Date issued = new Date();
+        final Date expires = new Date(issued.getTime()+24*60*60*1000);
+        when(osClient.getAccess().getToken().getExpires()).thenReturn(expires);
         ImageService imageService = mock(ImageService.class);
         when(osClient.images()).thenReturn(imageService);
         doReturn(Collections.singletonList(image)).when(imageService).listAll();


### PR DESCRIPTION
Multiple issues combine to cause us to continue to use an `Openstack` instance long past the time when the login session has expired.
 - We need them to be valid through to the end of long-running operations, e.g. `bootAndWait`
 - Our local system time may be "slow" compared to the OpenStack service endpoint's idea of the current time.
 - Our own clock can drift over time.
 - We mis-read expires_at timestamps of format "_YYYY-MM-DDThh:mm:ss.SSSSSS_" to mean "_YYYY-MM-DDThh:mm:ss_ + _SSSSSS_ **milli**seconds" (but it should be "_YYYY-MM-DDThh:mm:ss_ + _SSSSSS_ **micro**seconds), causing us to mis-read the time by up to 16m39s (999000ms); See [JENKINS-46541](https://issues.jenkins-ci.org/browse/JENKINS-46541).
 - `JCloudsClouds.getOpenstack()` cached the `Openstack` instance indefinitely.