### PR TITLE
Cache data we get back from Openstack service endpoint.

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/internal/CacheableData.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/internal/CacheableData.java
@@ -1,0 +1,31 @@
+package jenkins.plugins.openstack.compute.internal;
+
+/**
+ * A stateless, deterministic, function that takes no arguments whose result can
+ * be cached.
+ * <p>
+ * When communicating with an OpenStack endpoint, we often request the same
+ * information, e.g. "Tell me what boot images are defined", and the answers
+ * don't change often. It makes some sense to cache these answers (for a short
+ * period of time) so that we can avoid making the same API calls over and over
+ * again in parallel.
+ * </p>
+ * This can have a noticeable effect on overall UI responsiveness, e.g. the
+ * cloud configuration page when there are a lot of templates defined.
+ *
+ * @param <T>
+ *            The type of data the function returns.
+ */
+public interface CacheableData<T> {
+    /**
+     * Gets the result of calling this function. The result may have come from
+     * the cache, or may have been calculated in-line.
+     * <p>
+     * <b>NOTE:</b> If the calculation throws a {@link RuntimeException}, this
+     * will be cached too.
+     * </p>
+     * 
+     * @return The answer.
+     */
+    public T get();
+}

--- a/src/main/java/jenkins/plugins/openstack/compute/internal/CacheableFunction.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/internal/CacheableFunction.java
@@ -1,0 +1,35 @@
+package jenkins.plugins.openstack.compute.internal;
+
+/**
+ * A stateless, deterministic, function that takes a single argument whose
+ * result can be cached.
+ * <p>
+ * When communicating with an OpenStack endpoint, we often request the same
+ * information, e.g. "Tell me what boot images are defined", and the answers
+ * don't change often. It makes some sense to cache these answers (for a short
+ * period of time) so that we can avoid making the same API calls over and over
+ * again in parallel.
+ * </p>
+ * This can have a noticeable effect on overall UI responsiveness, e.g. the
+ * cloud configuration page when there are a lot of templates defined.
+ *
+ * @param <A>
+ *            The function's argument type.
+ * @param <R>
+ *            The type of data the function returns.
+ */
+public interface CacheableFunction<A, R> {
+    /**
+     * Gets the result of calling this function with the given argument. The
+     * result may have come from the cache, or may have been calculated in-line.
+     * <p>
+     * <b>NOTE:</b> If the calculation throws a {@link RuntimeException}, this
+     * will be cached too.
+     * </p>
+     * 
+     * @param arg
+     *            The argument.
+     * @return The answer.
+     */
+    public R get(A arg);
+}

--- a/src/main/java/jenkins/plugins/openstack/compute/internal/CachedData.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/internal/CachedData.java
@@ -1,0 +1,40 @@
+package jenkins.plugins.openstack.compute.internal;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Implementation of {@link CacheableData} that requires {@link #calculate()} to
+ * be implemented.
+ *
+ * @param <V>
+ *            See {@link CacheableData}
+ */
+public abstract class CachedData<V> implements CacheableData<V> {
+    @Restricted(NoExternalUse.class) // non-private just for testing
+    final CacheableFunction<String, V> cache;
+
+    protected CachedData(final int secondsToCacheData) {
+        cache = new CachedFunction<String, V>(secondsToCacheData) {
+            @Override
+            protected V calculate(String ignored) {
+                return CachedData.this.calculate();
+            }
+        };
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public V get() {
+        return cache.get("");
+    }
+
+    /**
+     * The function whose results should be cached.
+     * 
+     * @return The result to be cached.
+     * @throws RuntimeException
+     *             If thrown, this will be cached too.
+     */
+    protected abstract V calculate();
+}

--- a/src/main/java/jenkins/plugins/openstack/compute/internal/CachedFunction.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/internal/CachedFunction.java
@@ -1,0 +1,186 @@
+package jenkins.plugins.openstack.compute.internal;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+/**
+ * Implementation of {@link CacheableFunction} that requires
+ * {@link #calculate(Object)} to be implemented.
+ *
+ * @param <K>
+ *            See {@link CacheableFunction}
+ * @param <V>
+ *            See {@link CacheableFunction}
+ */
+public abstract class CachedFunction<K, V> implements CacheableFunction<K, V> {
+
+    @Restricted(NoExternalUse.class) // non-private just for testing
+    /**
+     * The index (in the cache) we use if the function's actual argument is
+     * null.
+     */
+    static final Object NULL = new Object();
+
+    @Restricted(NoExternalUse.class) // non-private just for testing
+    /** Holds the result of calling the function. */
+    class Result {
+        /** If non-null then the function threw this exception. */
+        @CheckForNull
+        final RuntimeException ex;
+        /**
+         * If <code>ex</code> is not null then this is the original stacktrace
+         * from it.
+         */
+        final StackTraceElement[] exOriginalStacktrace;
+        /**
+         * If <code>ex</code> is null then this is the result returned by the
+         * function
+         */
+        final V value;
+
+        Result(V value) {
+            this.value = value;
+            this.ex = null;
+            this.exOriginalStacktrace = null;
+        }
+
+        Result(RuntimeException ex) {
+            this.ex = ex;
+            this.exOriginalStacktrace = ex.getStackTrace();
+            this.value = null;
+        }
+    }
+
+    @Restricted(NoExternalUse.class) // non-private just for testing
+    /** Indexed by method argument. */
+    final @Nonnull Cache<Object, Result> cache;
+
+    private static final String OURCLASSNAME = CachedFunction.class.getName();
+
+    /**
+     * Creates an empty cache, setting the data expiry lifetime.
+     * 
+     * @param secondsToCacheData
+     *            The number of seconds that the data remains valid after being
+     *            calculated.
+     */
+    protected CachedFunction(final int secondsToCacheData) {
+        cache = CacheBuilder.newBuilder().expireAfterWrite(secondsToCacheData, TimeUnit.SECONDS).build();
+    }
+
+    /**
+     * The function whose results should be cached.
+     * 
+     * @param key
+     *            The argument to be given to the function.
+     * @return The result to be cached.
+     * @throws RuntimeException
+     *             If thrown, this will be cached too.
+     */
+    protected abstract V calculate(K key);
+
+    /** {@inheritDoc} */
+    @Override
+    public V get(final K key) {
+        final Callable<Result> callOnCacheMiss = new Callable<Result>() {
+            @Override
+            public Result call() {
+                try {
+                    return new Result(calculate(key));
+                } catch (RuntimeException e) {
+                    return new Result(e);
+                }
+            }
+        };
+        final Object cacheKey = key == null ? NULL : key;
+        final Result result;
+        try {
+            result = cache.get(cacheKey, callOnCacheMiss);
+        } catch (ExecutionException e) {
+            // Should not happen as our callOnCacheMiss method does not throw
+            // a declared exceptions and any RuntimeExceptions thrown by the
+            // calculate method will have been caught and stored in the result.
+            throw new RuntimeException("Internal error", e);
+        }
+        // If we got an exception, pass that back...
+        if (result.ex != null) {
+            // NOTE: If you are debugging an exception stacktrace and you are
+            // pointed to the following line, please be aware that this is where
+            // get() was called from this time, but all the deeper stacktrace
+            // elements came from the original exception from when the value was
+            // first calculated (and cached), which might not be from this time
+            // if "this time" was a cache-hit.
+            final List<StackTraceElement> howWeGotHereThisTime = createStacktracePointingHere();
+            final StackTraceElement[] st = combineHowWeGotHereWithTheOriginalStacktrace(howWeGotHereThisTime,
+                    result.exOriginalStacktrace);
+            result.ex.setStackTrace(st);
+            throw result.ex;
+        }
+        // ...otherwise return the result.
+        return result.value;
+    }
+
+    /**
+     * When we are returning the "same exception" that we cached previously, we
+     * need to re-throw the exact same exception (same instance) that was thrown
+     * when we calculated the results (in order to ensure that cache-hit
+     * behavior is the same as cache-miss behavior) BUT the stacktrace from the
+     * cached result will be very misleading if left as-is (it'll show us being
+     * called from whatever code experienced the cache-miss), so we take the
+     * exception's original stacktrace (up to where we got involved) and then
+     * glue our current stacktrace (from where we got involved onwards) on to
+     * the end of that.
+     * 
+     * @param howWeGotHereThisTime
+     *            Our current stacktrace up to where we got involved.
+     * @param originalExceptionStacktrace
+     *            The original exception stacktrace.
+     * @return A stacktrace showing the cache-miss code path plus how we got to
+     *         this point.
+     */
+    private static StackTraceElement[] combineHowWeGotHereWithTheOriginalStacktrace(
+            final List<StackTraceElement> howWeGotHereThisTime, final StackTraceElement[] originalExceptionStacktrace) {
+        final List<StackTraceElement> combined = new ArrayList<>(
+                howWeGotHereThisTime.size() + originalExceptionStacktrace.length);
+        for (final StackTraceElement orig : originalExceptionStacktrace) {
+            combined.add(orig);
+            if (orig.getClassName().equals(OURCLASSNAME)) {
+                break;
+            }
+        }
+        combined.addAll(howWeGotHereThisTime);
+        final StackTraceElement[] newTrace = combined.toArray(new StackTraceElement[combined.size()]);
+        return newTrace;
+    }
+
+    /**
+     * @return a stacktrace from the top of the {@link Thread#currentThread()}
+     *         down to the code which call this method, excluding the call to
+     *         this method.
+     */
+    private static List<StackTraceElement> createStacktracePointingHere() {
+        // get stacktrace
+        final ArrayList<StackTraceElement> l = new ArrayList<>(Arrays.asList(Thread.currentThread().getStackTrace()));
+        // now strip off until we find this class, which should leave us
+        // pointing at this method
+        while (!l.isEmpty() && !l.get(0).getClassName().equals(OURCLASSNAME))
+            l.remove(0);
+        // and remove this method too
+        if (!l.isEmpty())
+            l.remove(0);
+        return l;
+    }
+}

--- a/src/test/java/jenkins/plugins/openstack/compute/internal/CachedDataTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/internal/CachedDataTest.java
@@ -1,0 +1,147 @@
+package jenkins.plugins.openstack.compute.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+public class CachedDataTest {
+    private static final Object VALUE = "Value1";
+    private static final Object VALUENULL = null;
+
+    @Test
+    public void getWhenCacheMissThenResultCalculated() {
+        final CacheableData<Object> mockFn = mock(CacheableData.class);
+        final CachedData<Object> instance = mkInstance(Integer.MAX_VALUE, mockFn);
+        when(mockFn.get()).thenReturn(VALUE);
+
+        final Object actual = instance.get();
+
+        assertThat(actual, sameInstance(VALUE));
+        verify(mockFn, times(1)).get();
+        verifyNoMoreInteractions(mockFn);
+    }
+
+    @Test
+    public void getWhenCacheHitThenResultReturnedNotCalculated() {
+        final CacheableData<Object> mockFn = mock(CacheableData.class);
+        final CachedData<Object> instance = mkInstance(Integer.MAX_VALUE, mockFn);
+        putValueCache(instance, VALUE);
+
+        final Object actual = instance.get();
+
+        assertThat(actual, sameInstance(VALUE));
+        verifyNoMoreInteractions(mockFn);
+    }
+
+    @Test
+    public void getWhenCacheMissAndCalculationReturnsNullThenReturnsNull() {
+        final CacheableData<Object> mockFn = mock(CacheableData.class);
+        final CachedData<Object> instance = mkInstance(Integer.MAX_VALUE, mockFn);
+        when(mockFn.get()).thenReturn(VALUENULL);
+
+        final Object actual = instance.get();
+
+        assertThat(actual, sameInstance(VALUENULL));
+        verify(mockFn, times(1)).get();
+        verifyNoMoreInteractions(mockFn);
+    }
+
+    @Test
+    public void getWhenCacheHitAndCalculationWasNullThenReturnsNull() {
+        final CacheableData<Object> mockFn = mock(CacheableData.class);
+        final CachedData<Object> instance = mkInstance(Integer.MAX_VALUE, mockFn);
+        putValueCache(instance, VALUENULL);
+
+        final Object actual = instance.get();
+
+        assertThat(actual, sameInstance(VALUENULL));
+        verifyNoMoreInteractions(mockFn);
+    }
+
+    @Test
+    public void getWhenCacheMissAndCalculationThrowsRTEThenThrowsRTE() {
+        final CacheableData<Object> mockFn = mock(CacheableData.class);
+        final CachedData<Object> instance = mkInstance(Integer.MAX_VALUE, mockFn);
+        final ExpectedRTE rte = new ExpectedRTE();
+        when(mockFn.get()).thenThrow(rte);
+
+        try {
+            instance.get();
+            fail();
+        } catch (ExpectedRTE actual) {
+            assertThat(actual, sameInstance(rte));
+        }
+        verify(mockFn, times(1)).get();
+        verifyNoMoreInteractions(mockFn);
+    }
+
+    @Test
+    public void getWhenCacheHitAndCalculationThrewRTEThenThrowsRTE() {
+        final CacheableData<Object> mockFn = mock(CacheableData.class);
+        final CachedData<Object> instance = mkInstance(Integer.MAX_VALUE, mockFn);
+        final ExpectedRTE rte = new ExpectedRTE();
+        putExceptionCache(instance, rte);
+
+        try {
+            instance.get();
+            fail();
+        } catch (ExpectedRTE actual) {
+            assertThat(actual, sameInstance(rte));
+        }
+        verifyNoMoreInteractions(mockFn);
+    }
+
+    @Test
+    public void getWithSameArgWhenCacheHasExpiredThenResultsRecalculated() throws Exception {
+        final CacheableData<Object> mockFn = mock(CacheableData.class);
+        final int cacheTimeoutSeconds = 1;
+        final long cacheTimeoutMilliseconds = cacheTimeoutSeconds * 1000L;
+        final CachedData<Object> instance = mkInstance(1, mockFn);
+        when(mockFn.get()).thenReturn(VALUE);
+        putValueCache(instance, VALUE);
+
+        final Object actual1a = instance.get(); // from cache
+        Thread.sleep(cacheTimeoutMilliseconds / 2L);
+        final Object actual1b = instance.get(); // from cache
+        Thread.sleep(cacheTimeoutMilliseconds);
+        final Object actual1c = instance.get(); // recalculated
+
+        assertThat(actual1a, sameInstance(VALUE));
+        assertThat(actual1b, sameInstance(VALUE));
+        assertThat(actual1c, sameInstance(VALUE));
+        verify(mockFn, times(1)).get();
+        verifyNoMoreInteractions(mockFn);
+    }
+
+    private static <V> CachedData<V> mkInstance(int cacheTimeout, final CacheableData<V> calculationDelegate) {
+        return new CachedData<V>(cacheTimeout) {
+            @Override
+            protected V calculate() {
+                return calculationDelegate.get();
+            }
+        };
+    }
+
+    private static <V> void putValueCache(CachedData<V> instance, V value) {
+        final CachedFunction<String, V> cf = (CachedFunction<String, V>) instance.cache;
+        final CachedFunction<String, V>.Result r = cf.new Result(value);
+        cf.cache.put("", r);
+    }
+
+    private static <V> void putExceptionCache(CachedData<V> instance, RuntimeException ex) {
+        final CachedFunction<String, V> cf = (CachedFunction<String, V>) instance.cache;
+        final CachedFunction<String, V>.Result r = cf.new Result(ex);
+        cf.cache.put("", r);
+    }
+
+    private static class ExpectedRTE extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+    }
+}

--- a/src/test/java/jenkins/plugins/openstack/compute/internal/CachedFunctionTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/internal/CachedFunctionTest.java
@@ -1,0 +1,337 @@
+package jenkins.plugins.openstack.compute.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+public class CachedFunctionTest {
+    private static final Object ARG1 = "ARG1";
+    private static final Object ARG2 = "ARG2";
+    private static final Object ARG3 = "ARG3";
+    private static final Object ARGNULL = null;
+    private static final Object VALUE1 = "Value1";
+    private static final Object VALUE2 = "Value2";
+    private static final Object VALUE3 = "Value3";
+    private static final Object VALUENULL = null;
+
+    @Test
+    public void getWhenCacheMissThenResultCalculated() {
+        final CacheableFunction<Object, Object> mockFn = mock(CacheableFunction.class);
+        final CachedFunction<Object, Object> instance = mkInstance(Integer.MAX_VALUE, mockFn);
+        when(mockFn.get(ARG1)).thenReturn(VALUE1);
+
+        final Object actual = instance.get(ARG1);
+
+        assertThat(actual, sameInstance(VALUE1));
+        verify(mockFn, times(1)).get(ARG1);
+        verifyNoMoreInteractions(mockFn);
+    }
+
+    @Test
+    public void getWhenCacheHitThenResultReturnedNotCalculated() {
+        final CacheableFunction<Object, Object> mockFn = mock(CacheableFunction.class);
+        final CachedFunction<Object, Object> instance = mkInstance(Integer.MAX_VALUE, mockFn);
+        putValueCache(instance, ARG1, VALUE1);
+
+        final Object actual = instance.get(ARG1);
+
+        assertThat(actual, sameInstance(VALUE1));
+        verifyNoMoreInteractions(mockFn);
+    }
+
+    @Test
+    public void getWithNullArgWhenCacheMissThenResultCalculatedForNullArg() {
+        final CacheableFunction<Object, Object> mockFn = mock(CacheableFunction.class);
+        final CachedFunction<Object, Object> instance = mkInstance(Integer.MAX_VALUE, mockFn);
+        when(mockFn.get(ARGNULL)).thenReturn(VALUE3);
+
+        final Object actual = instance.get(ARGNULL);
+
+        assertThat(actual, sameInstance(VALUE3));
+        verify(mockFn, times(1)).get(ARGNULL);
+        verifyNoMoreInteractions(mockFn);
+    }
+
+    @Test
+    public void getWithNullArgWhenCacheHitThenResultReturnedNotCalculated() {
+        final CacheableFunction<Object, Object> mockFn = mock(CacheableFunction.class);
+        final CachedFunction<Object, Object> instance = mkInstance(Integer.MAX_VALUE, mockFn);
+        putValueCache(instance, ARGNULL, VALUE3);
+
+        final Object actual = instance.get(ARGNULL);
+
+        assertThat(actual, sameInstance(VALUE3));
+        verifyNoMoreInteractions(mockFn);
+    }
+
+    @Test
+    public void getWhenCacheMissAndCalculationReturnsNullThenReturnsNull() {
+        final CacheableFunction<Object, Object> mockFn = mock(CacheableFunction.class);
+        final CachedFunction<Object, Object> instance = mkInstance(Integer.MAX_VALUE, mockFn);
+        when(mockFn.get(ARG3)).thenReturn(VALUENULL);
+
+        final Object actual = instance.get(ARG3);
+
+        assertThat(actual, sameInstance(VALUENULL));
+        verify(mockFn, times(1)).get(ARG3);
+        verifyNoMoreInteractions(mockFn);
+    }
+
+    @Test
+    public void getWhenCacheHitAndCalculationWasNullThenReturnsNull() {
+        final CacheableFunction<Object, Object> mockFn = mock(CacheableFunction.class);
+        final CachedFunction<Object, Object> instance = mkInstance(Integer.MAX_VALUE, mockFn);
+        putValueCache(instance, ARG3, VALUENULL);
+
+        final Object actual = instance.get(ARG3);
+
+        assertThat(actual, sameInstance(VALUENULL));
+        verifyNoMoreInteractions(mockFn);
+    }
+
+    @Test
+    public void getWhenCacheMissAndCalculationThrowsRTEThenThrowsRTEShowingStacktraceToException() {
+        final AtomicReference<ExpectedRTE> refToEx = new AtomicReference<>();
+        final AtomicReference<StackTraceElement[]> refToExOrigSTE = new AtomicReference<>();
+        final CachedFunction<Object, Object> instance = new CachedFunction<Object, Object>(Integer.MAX_VALUE) {
+            @Override
+            protected Object calculate(Object key) {
+                final ExpectedRTE ex = new ExpectedRTE();
+                refToEx.set(ex);
+                refToExOrigSTE.set(ex.getStackTrace());
+                throw ex;
+            }
+        };
+
+        final ExpectedRTE actual;
+        try {
+            instance.get(ARG1);
+            fail();
+            return; // prevent compiler warning
+        } catch (ExpectedRTE ex) {
+            actual = ex;
+        }
+        assertThat(actual, sameInstance(refToEx.get()));
+        final StackTraceElement[] origSTE = refToExOrigSTE.get();
+        final List<StackTraceElement> expectedDeepest = getDeepestSTEsThatAreOurCode(origSTE);
+        final List<StackTraceElement> expectedHighest = getHighestSTEsUpToAndIncludingOurTestCode(origSTE);
+        final String actualSTString = toMLString(actual.getStackTrace());
+        final String expectedStartString = toMLString(expectedDeepest);
+        final String expectedEndString = toMLString(expectedHighest);
+        assertThat(actualSTString, startsWith(expectedStartString));
+        assertThat(actualSTString, endsWith(expectedEndString));
+    }
+
+    @Test
+    public void getWhenCacheHitAndCalculationThrewRTEThenThrowsRTEShowingStacktraceFromCacheHitToException()
+            throws InterruptedException {
+        final AtomicReference<ExpectedRTE> ref = new AtomicReference<>();
+        final CacheableFunction<Object, Object> mockFn = mock(CacheableFunction.class);
+        final CachedFunction<Object, Object> instance = new CachedFunction<Object, Object>(Integer.MAX_VALUE) {
+            @Override
+            protected Object calculate(Object key) {
+                if (ref.get() == null) {
+                    final ExpectedRTE ex = new ExpectedRTE();
+                    ref.set(ex);
+                    throw ex;
+                }
+                return mockFn.get(key);
+            }
+        };
+        final Thread createRteInAnotherContext = new Thread() {
+            @Override
+            public void run() {
+                try {
+                    instance.get(ARG1);
+                } catch (ExpectedRTE ignored) {
+                }
+            }
+        };
+        createRteInAnotherContext.start();
+        createRteInAnotherContext.join(1000L);
+        final ExpectedRTE rte = ref.get();
+        final StackTraceElement[] origSTE = rte.getStackTrace();
+
+        final ExpectedRTE actual;
+        try {
+            instance.get(ARG1);
+            fail();
+            return; // prevent compiler warning
+        } catch (ExpectedRTE ex) {
+            actual = ex;
+        }
+        assertThat(actual, sameInstance(rte));
+        final List<StackTraceElement> expectedDeepest = getDeepestSTEsThatAreOurCode(origSTE);
+        final List<StackTraceElement> unwantedHighest = Collections.singletonList(origSTE[origSTE.length - 1]);
+        final String actualSTString = toMLString(actual.getStackTrace());
+        final String expectedStartString = toMLString(expectedDeepest);
+        final String unwantedEndString = toMLString(unwantedHighest);
+        assertThat(actualSTString, startsWith(expectedStartString));
+        assertThat(actualSTString, not(endsWith(unwantedEndString)));
+        verifyNoMoreInteractions(mockFn);
+    }
+
+    @Test
+    public void getWithVariousArgsThenCachesResults() {
+        final CacheableFunction<Object, Object> mockFn = mock(CacheableFunction.class);
+        final CachedFunction<Object, Object> instance = mkInstance(Integer.MAX_VALUE, mockFn);
+        final ExpectedRTE rte = new ExpectedRTE();
+        when(mockFn.get(ARG1)).thenReturn(VALUE1);
+        when(mockFn.get(ARG2)).thenReturn(VALUE2);
+        when(mockFn.get(ARG3)).thenThrow(rte);
+        when(mockFn.get(ARGNULL)).thenReturn(VALUENULL);
+
+        final Object actual1a = instance.get(ARG1);
+        final Object actual2a = instance.get(ARG2);
+        final ExpectedRTE actual3a;
+        try {
+            instance.get(ARG3);
+            fail();
+            return;
+        } catch (ExpectedRTE actual) {
+            actual3a = actual;
+        }
+        final Object actual4a = instance.get(ARGNULL);
+        final Object actual1b = instance.get(ARG1);
+        final Object actual2b = instance.get(ARG2);
+        final ExpectedRTE actual3b;
+        try {
+            instance.get(ARG3);
+            fail();
+            return;
+        } catch (ExpectedRTE actual) {
+            actual3b = actual;
+        }
+        final Object actual4b = instance.get(ARGNULL);
+
+        assertThat(actual1a, sameInstance(VALUE1));
+        assertThat(actual2a, sameInstance(VALUE2));
+        assertThat(actual3a, sameInstance(rte));
+        assertThat(actual4a, sameInstance(VALUENULL));
+        assertThat(actual1b, sameInstance(VALUE1));
+        assertThat(actual2b, sameInstance(VALUE2));
+        assertThat(actual3b, sameInstance(rte));
+        assertThat(actual4b, sameInstance(VALUENULL));
+        verify(mockFn, times(1)).get(ARG1);
+        verify(mockFn, times(1)).get(ARG2);
+        verify(mockFn, times(1)).get(ARG3);
+        verify(mockFn, times(1)).get(ARGNULL);
+        verifyNoMoreInteractions(mockFn);
+    }
+
+    @Test
+    public void getWithSameArgWhenCacheHasExpiredThenResultsRecalculated() throws Exception {
+        final CacheableFunction<Object, Object> mockFn = mock(CacheableFunction.class);
+        final int cacheTimeoutSeconds = 1;
+        final long cacheTimeoutMilliseconds = cacheTimeoutSeconds * 1000L;
+        final CachedFunction<Object, Object> instance = mkInstance(1, mockFn);
+        when(mockFn.get(ARG1)).thenReturn(VALUE1);
+        when(mockFn.get(ARG2)).thenReturn(VALUE2);
+        putValueCache(instance, ARG1, VALUE1); // data should remain for period
+                                               // from here
+
+        final Object actual1a = instance.get(ARG1); // data from cache
+        final Object actual2a = instance.get(ARG2); // data calculated and
+                                                    // cached
+        Thread.sleep(cacheTimeoutMilliseconds / 2L);
+        final Object actual1b = instance.get(ARG1); // data from cache
+        final Object actual2b = instance.get(ARG2); // data from cache
+        Thread.sleep(cacheTimeoutMilliseconds);
+        final Object actual1c = instance.get(ARG1); // data was cached,
+                                                    // recalculated
+        final Object actual2c = instance.get(ARG2); // data was cached,
+                                                    // recalculated
+
+        assertThat(actual1a, sameInstance(VALUE1));
+        assertThat(actual2a, sameInstance(VALUE2));
+        assertThat(actual1b, sameInstance(VALUE1));
+        assertThat(actual2b, sameInstance(VALUE2));
+        assertThat(actual1c, sameInstance(VALUE1));
+        assertThat(actual2c, sameInstance(VALUE2));
+        verify(mockFn, times(1)).get(ARG1);
+        verify(mockFn, times(2)).get(ARG2);
+        verifyNoMoreInteractions(mockFn);
+    }
+
+    private static String toMLString(Iterable<?> l) {
+        final StringBuilder s = new StringBuilder();
+        for (Object o : l) {
+            s.append(o).append('\n');
+        }
+        return s.toString();
+    }
+
+    private static <T> String toMLString(T[] l) {
+        final List<T> list = Arrays.asList(l);
+        return toMLString(list);
+    }
+
+    private static List<StackTraceElement> getDeepestSTEsThatAreOurCode(StackTraceElement[] st) {
+        final List<StackTraceElement> res = new ArrayList<>();
+        for (final StackTraceElement ste : st) {
+            if (!steIsInOurCode(ste))
+                break;
+            res.add(ste);
+        }
+        return res;
+    }
+
+    private static List<StackTraceElement> getHighestSTEsUpToAndIncludingOurTestCode(StackTraceElement[] st) {
+        final List<StackTraceElement> res = new ArrayList<>();
+        boolean foundOurStuff = false;
+        for (int i = st.length - 1; i >= 0; i--) {
+            final StackTraceElement ste = st[i];
+            if (steIsInOurTestCode(ste)) {
+                foundOurStuff = true;
+            } else {
+                if (foundOurStuff)
+                    break; // have found the end of our stuff
+            }
+            res.add(0, ste);
+        }
+        return res;
+    }
+
+    private static boolean steIsInOurCode(final StackTraceElement ste) {
+        return ste.getClassName().startsWith(CachedFunctionTest.class.getPackage().getName());
+    }
+
+    private static boolean steIsInOurTestCode(final StackTraceElement ste) {
+        return ste.getClassName().startsWith(CachedFunctionTest.class.getName());
+    }
+
+    private static <K, V> CachedFunction<K, V> mkInstance(int cacheTimeout,
+            final CacheableFunction<K, V> calculationDelegate) {
+        return new CachedFunction<K, V>(cacheTimeout) {
+            @Override
+            protected V calculate(K key) {
+                return calculationDelegate.get(key);
+            }
+        };
+    }
+
+    private static <K, V> void putValueCache(CachedFunction<K, V> instance, K key, V value) {
+        final CachedFunction<K, V>.Result r = instance.new Result(value);
+        instance.cache.put(key == null ? CachedFunction.NULL : key, r);
+    }
+
+    private static class ExpectedRTE extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+    }
+}


### PR DESCRIPTION
A number of functions we call will return the same data no matter when or how we call them, e.g. the list of IP pools does not change often.
It should, therefore, be safe to cache such information and thus avoid making needless calls to the Openstack service, which in turn will improve UI responsiveness.
This change caches (for 15 seconds) the results of the following openstack4j calls:
 - compute().flavors().list()
 - compute().floatingIps().getPoolNames()
 - compute().keypairs().list()
 - images().listAll()
 - images().listAll(name)
 - networking().network().list()