### PR TITLE
add support for custom project domain in user identity.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
             <version>2.8</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>2.1.2</version>
+        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>

--- a/src/main/java/jenkins/plugins/openstack/compute/OsAuthDescriptor.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/OsAuthDescriptor.java
@@ -29,6 +29,7 @@ import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.util.ListBoxModel;
 import hudson.util.ReflectionUtils;
+import jenkins.plugins.openstack.compute.auth.OpenstackCredential;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.springframework.util.StringUtils;
@@ -94,7 +95,7 @@ public abstract class OsAuthDescriptor<DESCRIBABLE extends Describable<DESCRIBAB
 
         // Replace direct reference to references to possible relative paths
         if (method.getAnnotation(InjectOsAuth.class) != null) {
-            for (String attr: Arrays.asList("endPointUrl", "identity", "credential", "zone")) {
+            for (String attr: Arrays.asList("endPointUrl","credentialId", "zone")) {
                 deps.remove(attr);
                 for (String offset : getAuthFieldsOffsets()) {
                     deps.add(offset + "/" + attr);
@@ -107,8 +108,8 @@ public abstract class OsAuthDescriptor<DESCRIBABLE extends Describable<DESCRIBAB
         }
     }
 
-    protected static boolean haveAuthDetails(String endPointUrl, String identity, String credential, String zone) {
-        return Util.fixEmpty(endPointUrl)!=null && Util.fixEmpty(identity)!=null && Util.fixEmpty(credential)!=null;
+    protected static boolean haveAuthDetails(String endPointUrl, OpenstackCredential openstackCredential, String zone) {
+        return  Util.fixEmpty(endPointUrl)!=null && openstackCredential !=null;
     }
 
     public static String getDefault(String d1, Object d2) {

--- a/src/main/java/jenkins/plugins/openstack/compute/auth/AbstractOpenstackCredential.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/auth/AbstractOpenstackCredential.java
@@ -1,0 +1,16 @@
+package jenkins.plugins.openstack.compute.auth;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import hudson.ExtensionPoint;
+
+
+public abstract class AbstractOpenstackCredential extends BaseStandardCredentials implements OpenstackCredential,ExtensionPoint {
+
+
+    public AbstractOpenstackCredential(@CheckForNull CredentialsScope scope,
+                               @CheckForNull String id, @CheckForNull String description) {
+        super(scope, id, description);
+    }
+}

--- a/src/main/java/jenkins/plugins/openstack/compute/auth/OpenstackCredential.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/auth/OpenstackCredential.java
@@ -1,0 +1,14 @@
+package jenkins.plugins.openstack.compute.auth;
+
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import org.openstack4j.api.OSClient;
+import org.openstack4j.api.client.IOSClientBuilder;
+
+/**
+ * Represents the credentials to connect to Openstack
+ */
+public interface OpenstackCredential extends StandardCredentials {
+
+    IOSClientBuilder<? extends OSClient, ?> getBuilder(String endPointUrl);
+
+}

--- a/src/main/java/jenkins/plugins/openstack/compute/auth/OpenstackCredentials.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/auth/OpenstackCredentials.java
@@ -1,0 +1,34 @@
+package jenkins.plugins.openstack.compute.auth;
+
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import hudson.security.ACL;
+import jenkins.model.Jenkins;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+public class OpenstackCredentials {
+
+    public static OpenstackCredential getCredential(String credentialId) {
+        List<OpenstackCredential> credentials =
+                CredentialsProvider.lookupCredentials(
+                        OpenstackCredential.class, Jenkins.getInstance(), ACL.SYSTEM,
+                        Collections.<DomainRequirement>emptyList());
+        OpenstackCredential openstackCredential =
+                CredentialsMatchers.firstOrNull(credentials,
+                        CredentialsMatchers.allOf(CredentialsMatchers.withId(credentialId)));
+        return openstackCredential;
+    }
+
+    public static void add(OpenstackCredential openstackCredential) {
+        SystemCredentialsProvider.getInstance().getCredentials().add(openstackCredential);
+    }
+
+    public static void save() throws IOException {
+       SystemCredentialsProvider.getInstance().save();
+    }
+}

--- a/src/main/java/jenkins/plugins/openstack/compute/auth/OpenstackCredentialv2.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/auth/OpenstackCredentialv2.java
@@ -1,0 +1,105 @@
+package jenkins.plugins.openstack.compute.auth;
+
+import com.cloudbees.plugins.credentials.CredentialsNameProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.NameWith;
+import com.cloudbees.plugins.credentials.common.PasswordCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.Util;
+import hudson.util.Secret;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.openstack4j.api.OSClient;
+import org.openstack4j.api.client.IOSClientBuilder;
+import org.openstack4j.openstack.OSFactory;
+
+@NameWith(value = OpenstackCredentialv2.NameProvider.class)
+public class OpenstackCredentialv2 extends AbstractOpenstackCredential implements
+        StandardUsernamePasswordCredentials,PasswordCredentials {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Extension(ordinal = 1)
+    public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return "Openstack auth v2";
+        }
+
+    }
+
+    private final String tenant;
+    private final String username;
+    private final Secret password;
+
+
+    @DataBoundConstructor
+    @SuppressWarnings("unused")
+    public OpenstackCredentialv2(@CheckForNull CredentialsScope scope,
+                                 @CheckForNull String id, @CheckForNull String description,
+                                 @CheckForNull  String tenant, @CheckForNull  String username,
+                                 @CheckForNull  String password) {
+        this(scope,id,description,tenant, username,Secret.fromString(password));
+    }
+
+    @SuppressWarnings("unused")
+    public OpenstackCredentialv2(@CheckForNull CredentialsScope scope,
+                                 @CheckForNull String id, @CheckForNull String description,
+                                 @CheckForNull  String tenant, @CheckForNull  String username,
+                                 @CheckForNull  Secret password) {
+        super(scope,id,description);
+        this.tenant =  Util.fixEmptyAndTrim(tenant);
+        this.username =  Util.fixEmptyAndTrim(username);
+        this.password = password;
+    }
+
+    @NonNull
+    @Override
+    public Secret getPassword() {
+        return password;
+    }
+
+    @Override
+    public IOSClientBuilder<? extends OSClient, ?> getBuilder(String endPointUrl) {
+        return OSFactory.builderV2().endpoint(endPointUrl)
+                .credentials(username, getPassword().getPlainText())
+                .tenantName(tenant);
+    }
+
+    @Override
+    public String toString() {
+        return "OpenstackCredentialv2{" +
+                "tenant='" + tenant + '\'' +
+                ", username='" + username + '\'' +
+                '}';
+    }
+
+    public String getTenant() {
+        return tenant;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    @SuppressWarnings("unused")
+    public static class NameProvider extends CredentialsNameProvider<OpenstackCredentialv2> {
+
+        /**
+         * {@inheritDoc}
+         */
+        @NonNull
+        @Override
+        public String getName(@NonNull OpenstackCredentialv2 c) {
+            String description = Util.fixEmptyAndTrim(c.getDescription());
+            return c.getTenant() + ":" + c.getUsername() + "/******" + (description != null ? " (" + description + ")" : "");
+        }
+    }
+}

--- a/src/main/java/jenkins/plugins/openstack/compute/auth/OpenstackCredentialv3.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/auth/OpenstackCredentialv3.java
@@ -1,0 +1,131 @@
+package jenkins.plugins.openstack.compute.auth;
+
+import com.cloudbees.plugins.credentials.CredentialsNameProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.NameWith;
+import com.cloudbees.plugins.credentials.common.PasswordCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.Util;
+import hudson.util.Secret;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.openstack4j.api.OSClient;
+import org.openstack4j.api.client.IOSClientBuilder;
+import org.openstack4j.model.common.Identifier;
+import org.openstack4j.openstack.OSFactory;
+
+import javax.annotation.Nonnull;
+
+@NameWith(value = OpenstackCredentialv3.NameProvider.class)
+public class OpenstackCredentialv3 extends AbstractOpenstackCredential implements
+        StandardUsernamePasswordCredentials,PasswordCredentials {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Extension(ordinal = 1)
+    public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return "Openstack auth v3";
+        }
+
+    }
+
+    private final String username;
+    private final String userDomain;
+    private final String projectName;
+    private final String projectDomain;
+    private final Secret password;
+
+    @DataBoundConstructor
+    @SuppressWarnings("unused")
+    public OpenstackCredentialv3(@CheckForNull CredentialsScope scope,
+                                 @CheckForNull String id, @CheckForNull String description,
+                                 @Nonnull String username,
+                                 @Nonnull String userDomain, @Nonnull String projectName,
+                                 @Nonnull String projectDomain, @Nonnull String password) {
+        this(scope,id,description,username, userDomain, projectName, projectDomain, Secret.fromString(password));
+    }
+
+    @SuppressWarnings("unused")
+    public OpenstackCredentialv3(@CheckForNull CredentialsScope scope,
+                                 @CheckForNull String id, @CheckForNull String description,
+                                 @Nonnull String username, @Nonnull String userDomain, @Nonnull String projectName,
+                                 @Nonnull String projectDomain, @Nonnull Secret password) {
+        super(scope,id,description);
+        this.username = username;
+        this.userDomain = userDomain;
+        this.projectName = projectName;
+        this.projectDomain = projectDomain;
+        this.password = password;
+    }
+
+    @NonNull
+    @Override
+    public Secret getPassword() {
+        return password;
+    }
+
+    @Override
+    public IOSClientBuilder<? extends OSClient, ?> getBuilder(String endPointUrl) {
+
+        Identifier projectDomainIdentifier = Identifier.byName(projectDomain);
+        Identifier projectNameIdentifier = Identifier.byName(projectName);
+        Identifier userDomainIdentifier = Identifier.byName(userDomain);
+
+        return OSFactory.builderV3().endpoint(endPointUrl)
+                .credentials(username, getPassword().getPlainText(), userDomainIdentifier)
+                .scopeToProject(projectNameIdentifier, projectDomainIdentifier);
+    }
+
+    @Override
+    public String toString() {
+        return "OpenstackCredentialv3{" +
+                "username='" + username + '\'' +
+                ", userDomain='" + userDomain + '\'' +
+                ", projectName='" + projectName + '\'' +
+                ", projectDomain='" + projectDomain + '\'' +
+                '}';
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getUserDomain() {
+        return userDomain;
+    }
+
+    public String getProjectName() {
+        return projectName;
+    }
+
+    public String getProjectDomain() {
+        return projectDomain;
+    }
+
+    @SuppressWarnings("unused")
+    public static class NameProvider extends CredentialsNameProvider<OpenstackCredentialv3> {
+
+        /**
+         * {@inheritDoc}
+         */
+        @NonNull
+        @Override
+        public String getName(@NonNull OpenstackCredentialv3 c) {
+            String description = Util.fixEmptyAndTrim(c.getDescription());
+            return c.getProjectDomain() + ":"
+                    + c.getProjectName() + ":"
+                    + c.getUserDomain() + ":"
+                    + c.getUsername() + "/******"
+                    + (description != null ? " (" + description + ")" : "");
+        }
+    }
+}

--- a/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/config.jelly
+++ b/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/config.jelly
@@ -1,21 +1,18 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:c="lib/credentials">
     <f:entry title="Cloud Name" field="name">
         <f:textbox clazz="required"/>
     </f:entry>
     <f:entry title="End Point URL" field="endPointUrl">
         <f:textbox/>
     </f:entry>
-    <f:entry title="User Identity" field="identity">
-        <f:textbox clazz="required"/>
-    </f:entry>
-    <f:entry title="Password" field="credential">
-        <f:password clazz="required"/>
-    </f:entry>
+    <f:entry title="Credential" field="credentialId">
+        <c:select/>
+     </f:entry>
     <f:entry title="Region" field="zone">
         <f:textbox/>
     </f:entry>
-    <f:validateButton title="Test Connection" progress="${%Testing...}" method="testConnection" with="zone,endPointUrl,identity,credential"/>
+    <f:validateButton title="Test Connection" progress="${%Testing...}" method="testConnection" with="endPointUrl,credentialId,zone"/>
 
     <f:advanced title="Default slave options">
         <j:set var="defaultOpts" value="${descriptor.defaultOptions}"/>

--- a/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/help-credential.html
+++ b/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/help-credential.html
@@ -1,3 +1,0 @@
-<div>
-    Password of the user to start the machine.
-</div>

--- a/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/help-credentialId.html
+++ b/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/help-credentialId.html
@@ -1,0 +1,3 @@
+<div>
+    The credential to connect to openstack.
+</div>

--- a/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/help-identity.html
+++ b/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/help-identity.html
@@ -3,6 +3,6 @@
   The format required depends on the authentication method used by the OpenStack system.
   <ul>
   <li>For v2 authentication use syntax <tt>TENANT_NAME:USER_NAME</tt></li>
-  <li>For v3 authentication use syntax <tt>PROJECT_NAME:USER_NAME:DOMAIN_NAME</tt></li>
+  <li>For v3 authentication use syntax <tt>PROJECT_NAME:PROJECT_DOMAIN:USER_NAME:USER_DOMAIN_NAME</tt></li>
   </ul>
 </div>

--- a/src/main/resources/jenkins/plugins/openstack/compute/auth/OpenstackCredentialv2/config.jelly
+++ b/src/main/resources/jenkins/plugins/openstack/compute/auth/OpenstackCredentialv2/config.jelly
@@ -1,0 +1,13 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+  <f:entry title="Tenant Name" field="tenant">
+     <f:textbox clazz="required"/>
+  </f:entry>
+  <f:entry title="${%Username}" field="username">
+    <f:textbox  clazz="required"/>
+  </f:entry>
+  <f:entry title="${%Password}" field="password">
+    <f:password  clazz="required"/>
+  </f:entry>
+  <st:include page="id-and-description" class="${descriptor.clazz}"/>
+</j:jelly>

--- a/src/main/resources/jenkins/plugins/openstack/compute/auth/OpenstackCredentialv2/help-password.html
+++ b/src/main/resources/jenkins/plugins/openstack/compute/auth/OpenstackCredentialv2/help-password.html
@@ -1,0 +1,3 @@
+<div>
+    Password of the user.
+</div>

--- a/src/main/resources/jenkins/plugins/openstack/compute/auth/OpenstackCredentialv2/help-tenant.html
+++ b/src/main/resources/jenkins/plugins/openstack/compute/auth/OpenstackCredentialv2/help-tenant.html
@@ -1,0 +1,3 @@
+<div>
+    The tenant associated to the user.
+</div>

--- a/src/main/resources/jenkins/plugins/openstack/compute/auth/OpenstackCredentialv2/help-username.html
+++ b/src/main/resources/jenkins/plugins/openstack/compute/auth/OpenstackCredentialv2/help-username.html
@@ -1,0 +1,3 @@
+<div>
+    User name.
+</div>

--- a/src/main/resources/jenkins/plugins/openstack/compute/auth/OpenstackCredentialv3/config.jelly
+++ b/src/main/resources/jenkins/plugins/openstack/compute/auth/OpenstackCredentialv3/config.jelly
@@ -1,0 +1,19 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+    <f:entry title="Project Domain" field="projectDomain">
+        <f:textbox clazz="required"/>
+    </f:entry>
+    <f:entry title="Project Name" field="projectName">
+        <f:textbox clazz="required"/>
+    </f:entry>
+    <f:entry title="User Domain" field="userDomain">
+       <f:textbox clazz="required"/>
+    </f:entry>
+    <f:entry title="User Name" field="username">
+       <f:textbox clazz="required"/>
+     </f:entry>
+    <f:entry title="Password" field="password">
+        <f:password clazz="required"/>
+    </f:entry>
+  <st:include page="id-and-description" class="${descriptor.clazz}"/>
+</j:jelly>

--- a/src/main/resources/jenkins/plugins/openstack/compute/auth/OpenstackCredentialv3/help-password.html
+++ b/src/main/resources/jenkins/plugins/openstack/compute/auth/OpenstackCredentialv3/help-password.html
@@ -1,0 +1,3 @@
+<div>
+    Password of the user to connect to openstack.
+</div>

--- a/src/main/resources/jenkins/plugins/openstack/compute/auth/OpenstackCredentialv3/help-projectDomain.html
+++ b/src/main/resources/jenkins/plugins/openstack/compute/auth/OpenstackCredentialv3/help-projectDomain.html
@@ -1,0 +1,3 @@
+<div>
+    The domain name associated to the project to connect to openstack.
+</div>

--- a/src/main/resources/jenkins/plugins/openstack/compute/auth/OpenstackCredentialv3/help-projectName.html
+++ b/src/main/resources/jenkins/plugins/openstack/compute/auth/OpenstackCredentialv3/help-projectName.html
@@ -1,0 +1,3 @@
+<div>
+    The name of the project to connect to openstack.
+</div>

--- a/src/main/resources/jenkins/plugins/openstack/compute/auth/OpenstackCredentialv3/help-userDomain.html
+++ b/src/main/resources/jenkins/plugins/openstack/compute/auth/OpenstackCredentialv3/help-userDomain.html
@@ -1,0 +1,3 @@
+<div>
+    The domain name associated to the user to connect to openstack.
+</div>

--- a/src/main/resources/jenkins/plugins/openstack/compute/auth/OpenstackCredentialv3/help-username.html
+++ b/src/main/resources/jenkins/plugins/openstack/compute/auth/OpenstackCredentialv3/help-username.html
@@ -1,0 +1,3 @@
+<div>
+    User name of the user to connect to openstack.
+</div>

--- a/src/test/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplateTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplateTest.java
@@ -11,6 +11,7 @@ import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import hudson.remoting.Base64;
 import jenkins.plugins.openstack.PluginTestRule;
 
+import jenkins.plugins.openstack.compute.auth.OpenstackCredential;
 import jenkins.plugins.openstack.compute.internal.Openstack;
 import jenkins.plugins.openstack.compute.slaveopts.BootSource;
 import jenkins.plugins.openstack.compute.slaveopts.LauncherFactory;
@@ -38,10 +39,13 @@ public class JCloudsSlaveTemplateTest {
     public PluginTestRule j = new PluginTestRule();
 
     final String TEMPLATE_PROPERTIES = "name,labelString";
-    final String CLOUD_PROPERTIES = "name,identity,credential,endPointUrl,zone";
+    final String CLOUD_PROPERTIES = "name,credentialId,zone";
 
     @Test
     public void configRoundtrip() throws Exception {
+
+        final OpenstackCredential openstackCredential = mock(OpenstackCredential.class);
+
         JCloudsSlaveTemplate jnlpTemplate = new JCloudsSlaveTemplate(
                 "jnlp-template", "openstack-slave-type1 openstack-type2", PluginTestRule.dummySlaveOptions().getBuilder().launcherFactory(LauncherFactory.JNLP.JNLP).build()
         );
@@ -52,9 +56,10 @@ public class JCloudsSlaveTemplateTest {
         );
 
         JCloudsCloud originalCloud = new JCloudsCloud(
-                "my-openstack", "identity", "credential", "endPointUrl", "zone",
+                "my-openstack", "endPointUrl","zone",
                 SlaveOptions.empty(),
-                Arrays.asList(jnlpTemplate, sshTemplate)
+                Arrays.asList(jnlpTemplate, sshTemplate),
+                j.dummyCredential()
         );
 
         j.jenkins.clouds.add(originalCloud);
@@ -90,9 +95,10 @@ public class JCloudsSlaveTemplateTest {
         );
 
         JCloudsCloud cloud = new JCloudsCloud(
-                "my-openstack", "identity", "credential", "endPointUrl", "zone",
+                "my-openstack", "credential","zone",
                 cloudOpts,
-                Collections.singletonList(template)
+                Collections.singletonList(template),
+                j.dummyCredential()
         );
 
         assertEquals(cloudOpts, cloud.getRawSlaveOptions());

--- a/src/test/java/jenkins/plugins/openstack/compute/PersistenceMigrationTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/PersistenceMigrationTest.java
@@ -1,10 +1,15 @@
 package jenkins.plugins.openstack.compute;
 
+import com.cloudbees.plugins.credentials.CredentialsNameProvider;
 import hudson.model.TaskListener;
 import hudson.plugins.sshslaves.SSHLauncher;
 import hudson.slaves.ComputerLauncher;
 import hudson.slaves.JNLPLauncher;
 import jenkins.plugins.openstack.PluginTestRule;
+import jenkins.plugins.openstack.compute.auth.OpenstackCredential;
+import jenkins.plugins.openstack.compute.auth.OpenstackCredentials;
+import jenkins.plugins.openstack.compute.auth.OpenstackCredentialv2;
+import jenkins.plugins.openstack.compute.auth.OpenstackCredentialv3;
 import jenkins.plugins.openstack.compute.slaveopts.LauncherFactory;
 import org.junit.Rule;
 import org.junit.Test;
@@ -91,6 +96,25 @@ public class PersistenceMigrationTest {
         assertThat(launcherOf(inheritedCloud), instanceOf(SSHLauncher.class));
         assertThat(launcherOf(inheritedCloud.getTemplate("jnlp")), instanceOf(JNLPLauncher.class));
         assertThat(launcherOf(inheritedCloud.getTemplate("ssh")), instanceOf(SSHLauncher.class));
+    }
+
+
+    @Test @LocalData
+    public void loadConfigFromV29() throws Exception {
+        JCloudsCloud v2Cloud = JCloudsCloud.getByName("v2");
+        JCloudsCloud v3Cloud = JCloudsCloud.getByName("v3");
+
+        String cId = v2Cloud.getCredentialId();
+
+        OpenstackCredentialv2 v2 = (OpenstackCredentialv2) OpenstackCredentials.getCredential(v2Cloud.getCredentialId());
+        assertEquals("tenant:user/******",CredentialsNameProvider.name(v2));
+        assertEquals("OSQmsm29pf2vGWZEBlhAjUiJo/jhTfsUcMCgdIvwyXc=",v2.getPassword().getPlainText());
+
+        OpenstackCredentialv3 v3 = (OpenstackCredentialv3) OpenstackCredentials.getCredential(v3Cloud.getCredentialId());
+        assertEquals( "domain:project:domain:user/******",CredentialsNameProvider.name(v3));
+        assertEquals("OSQmsm29pf2vGWZEBlhAjUiJo/jhTfsUcMCgdIvwyXc=",v3.getPassword().getPlainText());
+
+
     }
 
     private static ComputerLauncher launcherOf(SlaveOptions.Holder holder) throws IOException {

--- a/src/test/java/jenkins/plugins/openstack/compute/slaveopts/BootSourceTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/slaveopts/BootSourceTest.java
@@ -74,9 +74,11 @@ public class BootSourceTest {
         when(image.getName()).thenReturn(imageName);
 
         Openstack os = j.fakeOpenstackFactory();
+        final String credentialId = j.dummyCredential();
+
         doReturn(Collections.singletonMap(imageName, Collections.singletonList(image))).when(os).getImages();
 
-        ListBoxModel list = id.doFillNameItems("", "OSurl", "OSid", "OSpwd", "OSzone");
+        ListBoxModel list = id.doFillNameItems("", "OSurl", credentialId, "OSzone");
         assertEquals(2, list.size());
         assertEquals("First menu entry is 'nothing selected'", "", list.get(0).value);
         ListBoxModel.Option item = list.get(1);
@@ -91,11 +93,12 @@ public class BootSourceTest {
         when(volumeSnapshot.getName()).thenReturn("vs-name");
         when(volumeSnapshot.getStatus()).thenReturn(Volume.Status.AVAILABLE);
         final Collection<VolumeSnapshot> justVolumeSnapshot = Collections.singletonList(volumeSnapshot);
+        final String credentialId = j.dummyCredential();
 
         Openstack os = j.fakeOpenstackFactory();
         when(os.getVolumeSnapshots()).thenReturn(Collections.singletonMap("vs-name", justVolumeSnapshot));
 
-        ListBoxModel list = vsd.doFillNameItems("existing-vs-name", "OSurl", "OSid", "OSpwd", "OSzone");
+        ListBoxModel list = vsd.doFillNameItems("existing-vs-name", "OSurl",credentialId, "OSzone");
         assertEquals(3, list.size());
         assertEquals("First menu entry is 'nothing selected'", "", list.get(0).value);
         assertEquals("Second menu entry is the VS OpenStack can see", "vs-name", list.get(1).name);
@@ -116,8 +119,10 @@ public class BootSourceTest {
         doReturn(Collections.singletonList(image)).when(imageService).listAll();
 
         j.fakeOpenstackFactory(new Openstack(osClient));
+        final String credentialId = j.dummyCredential();
 
-        ListBoxModel list = id.doFillNameItems("", "OSurl", "OSid", "OSpwd", "OSzone");
+
+        ListBoxModel list = id.doFillNameItems("", "OSurl", credentialId, "OSzone");
         assertThat(list.get(0).name, list, Matchers.<ListBoxModel.Option>iterableWithSize(2));
         assertEquals(2, list.size());
         ListBoxModel.Option item = list.get(1);
@@ -130,63 +135,74 @@ public class BootSourceTest {
 
     @Test
     public void doCheckImageIdWhenNoValueSet() throws Exception {
-        final String urlC, urlT, idC, idT, credC, credT, zoneC, zoneT;
-        urlC= urlT= idC= idT= credC= credT= zoneC= zoneT= "dummy";
+        final String urlC, urlT, zoneC, zoneT;
+        urlC= urlT= zoneC= zoneT= "dummy";
 
-        final FormValidation actual = id.doCheckName("", urlC, urlT, idC, idT, credC, credT, zoneC, zoneT);
+        final String credentialIdCloud = j.dummyCredential();
+        final String credentialIdTemplate = j.dummyCredential();
+
+        final FormValidation actual = id.doCheckName("",urlC,urlT, credentialIdCloud, credentialIdTemplate, zoneC, zoneT);
         assertThat(actual, hasState(VALIDATION_REQUIRED));
     }
 
     @Test
     public void doCheckImageIdWhenImageIsNotFoundInOpenstack() throws Exception {
-        final String urlC, urlT, idC, idT, credC, credT, zoneC, zoneT;
-        urlC= urlT= idC= idT= credC= credT= zoneC= zoneT= "dummy";
+        final String urlC, urlT,zoneC, zoneT;
+        urlC= urlT= zoneC= zoneT= "dummy";
         final Openstack os = mock(Openstack.class);
         final List<String> noIDs = Collections.emptyList();
+        final String credentialIdCloud = j.dummyCredential();
+        final String credentialIdTemplate = j.dummyCredential();
         when(os.getImageIdsFor("imageNotFound")).thenReturn(noIDs);
         j.fakeOpenstackFactory(os);
         final FormValidation expected = FormValidation.error("Not found");
 
-        final FormValidation actual = id.doCheckName("imageNotFound", urlC, urlT, idC, idT, credC, credT, zoneC, zoneT);
+        final FormValidation actual = id.doCheckName("imageNotFound", urlC, urlT,credentialIdCloud, credentialIdTemplate, zoneC, zoneT);
         assertThat(actual, hasState(expected));
     }
 
     @Test
     public void doCheckImageIdWhenOneImageIsFound() throws Exception {
-        final String urlC, urlT, idC, idT, credC, credT, zoneC, zoneT;
-        urlC= urlT= idC= idT= credC= credT= zoneC= zoneT= "dummy";
+        final String urlC, urlT, zoneC, zoneT;
+        urlC= urlT= zoneC= zoneT= "dummy";
         final Openstack os = mock(Openstack.class);
+        final String credentialIdCloud = j.dummyCredential();
+        final String credentialIdTemplate = j.dummyCredential();
         when(os.getImageIdsFor("imageFound")).thenReturn(Collections.singletonList("imageFoundId"));
         j.fakeOpenstackFactory(os);
         final FormValidation expected = FormValidation.ok();
 
-        final FormValidation actual = id.doCheckName("imageFound", urlC, urlT, idC, idT, credC, credT, zoneC, zoneT);
+        final FormValidation actual = id.doCheckName("imageFound",urlC, urlT, credentialIdCloud, credentialIdTemplate, zoneC, zoneT);
         assertThat(actual, hasState(expected));
     }
 
     @Test
     public void doCheckImageIdWhenMultipleImagesAreFoundForTheName() throws Exception {
-        final String urlC, urlT, idC, idT, credC, credT, zoneC, zoneT;
-        urlC= urlT= idC= idT= credC= credT= zoneC= zoneT= "dummy";
+        final String urlC, urlT, zoneC, zoneT;
+        urlC= urlT= zoneC= zoneT= "dummy";
         final Openstack os = mock(Openstack.class);
+        final String credentialIdCloud = j.dummyCredential();
+        final String credentialIdTemplate = j.dummyCredential();
         when(os.getImageIdsFor("imageAmbiguous")).thenReturn(Arrays.asList("imageAmbiguousId1", "imageAmbiguousId2"));
         j.fakeOpenstackFactory(os);
         final FormValidation expected = FormValidation.warning("Multiple matching results");
 
-        final FormValidation actual = id.doCheckName("imageAmbiguous", urlC, urlT, idC, idT, credC, credT, zoneC, zoneT);
+        final FormValidation actual = id.doCheckName("imageAmbiguous", urlC, urlT,credentialIdCloud, credentialIdTemplate, zoneC, zoneT);
         assertThat("imageAmbiguous", actual, hasState(expected));
     }
 
     @Test
     public void doCheckImageIdWhenOneVolumeSnapshotIsFound() throws Exception {
-        final String urlC, urlT, idC, idT, credC, credT, zoneC, zoneT;
-        urlC= urlT= idC= idT= credC= credT= zoneC= zoneT= "dummy";
+        final String urlC, urlT, zoneC, zoneT;
+        urlC= urlT= zoneC= zoneT= "dummy";
         final Openstack os = mock(Openstack.class);
+        final String credentialIdCloud = j.dummyCredential();
+        final String credentialIdTemplate = j.dummyCredential();
         when(os.getVolumeSnapshotIdsFor("vsFound")).thenReturn(Collections.singletonList("vsFoundId"));
         j.fakeOpenstackFactory(os);
         final FormValidation expected = FormValidation.ok();
 
-        final FormValidation actual = vsd.doCheckName("vsFound", urlC, urlT, idC, idT, credC, credT, zoneC, zoneT);
+        final FormValidation actual = vsd.doCheckName("vsFound", urlC, urlT,credentialIdCloud, credentialIdTemplate, zoneC, zoneT);
         assertThat("vsFound", actual, hasState(expected));
     }
 }

--- a/src/test/resources/jenkins/plugins/openstack/compute/PersistenceMigrationTest/loadConfigFromV29/config.xml
+++ b/src/test/resources/jenkins/plugins/openstack/compute/PersistenceMigrationTest/loadConfigFromV29/config.xml
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudson>
+  <disabledAdministrativeMonitors/>
+  <version>1.642.3</version>
+  <numExecutors>2</numExecutors>
+  <mode>NORMAL</mode>
+  <useSecurity>true</useSecurity>
+  <authorizationStrategy class="hudson.security.AuthorizationStrategy$Unsecured"/>
+  <securityRealm class="hudson.security.SecurityRealm$None"/>
+  <disableRememberMe>false</disableRememberMe>
+  <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
+  <workspaceDir>${JENKINS_HOME}/workspace/${ITEM_FULLNAME}</workspaceDir>
+  <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+  <jdks/>
+  <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+  <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+  <clouds>
+    <jenkins.plugins.openstack.compute.JCloudsCloud plugin="openstack-cloud@2.30-SNAPSHOT">
+      <name>v2</name>
+      <endPointUrl>http://localv2</endPointUrl>
+      <identity>tenant:user</identity>
+      <credential>OSQmsm29pf2vGWZEBlhAjUiJo/jhTfsUcMCgdIvwyXc=</credential>
+      <zone>default</zone>
+      <templates class="java.util.Collections$UnmodifiableRandomAccessList" resolves-to="java.util.Collections$UnmodifiableList">
+        <c class="empty-list"/>
+        <list class="empty-list"/>
+      </templates>
+      <slaveOptions/>
+    </jenkins.plugins.openstack.compute.JCloudsCloud>
+    <jenkins.plugins.openstack.compute.JCloudsCloud plugin="openstack-cloud@2.30-SNAPSHOT">
+      <name>v3</name>
+      <endPointUrl>http://localv3</endPointUrl>
+      <identity>project:user:domain</identity>
+      <credential>OSQmsm29pf2vGWZEBlhAjUiJo/jhTfsUcMCgdIvwyXc=</credential>
+      <templates class="java.util.Collections$UnmodifiableRandomAccessList" resolves-to="java.util.Collections$UnmodifiableList">
+        <c class="empty-list"/>
+        <list class="empty-list"/>
+      </templates>
+      <slaveOptions/>
+    </jenkins.plugins.openstack.compute.JCloudsCloud>
+  </clouds>
+  <quietPeriod>5</quietPeriod>
+  <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+  <views>
+    <hudson.model.AllView>
+      <owner class="hudson" reference="../../.."/>
+      <name>All</name>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+      <properties class="hudson.model.View$PropertyList"/>
+    </hudson.model.AllView>
+  </views>
+  <primaryView>All</primaryView>
+  <slaveAgentPort>0</slaveAgentPort>
+  <label></label>
+  <nodeProperties/>
+  <globalNodeProperties/>
+</hudson>


### PR DESCRIPTION
The changes add the ability to connect to openstack instances having
the project's domain name different from the domain name.
It introduces an optional format for the user identity field while
remaining compatible with previous configurations of the
plugin.