### PR TITLE
Use ok-http to prevent connection leak

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,14 +43,8 @@
         </dependency>
         <dependency>
             <groupId>org.pacesys.openstack4j.connectors</groupId>
-            <artifactId>openstack4j-httpclient</artifactId>
+            <artifactId>openstack4j-okhttp</artifactId>
             <version>${openstack4j.version}</version>
-        </dependency>
-        <!-- http://stackoverflow.com/a/29642453/2091470 -->
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Openstack4J use of httpclient results in connections leaking, switching to ok-http prevenloss in functionallity.

I'm experiencing this after few days of Jenkins running, by looking at `netstat` I see huge number of connections (5-6 thousand) in CLOSE_WAIT state.

This issue could be related https://github.com/ContainX/openstack4j/issues/579