### PR TITLE
Add boot from volume with images

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
@@ -125,7 +125,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
                 lf = LauncherFactory.JNLP.JNLP;
             }
 
-            slaveOptions = SlaveOptions.builder().bootSource(new BootSource.Image(imageId, false, 0)).hardwareId(hardwareId).numExecutors(Integer.getInteger(numExecutors)).jvmOptions(jvmOptions).userDataId(userDataId)
+            slaveOptions = SlaveOptions.builder().bootSource(new BootSource.Image(imageId, null)).hardwareId(hardwareId).numExecutors(Integer.getInteger(numExecutors)).jvmOptions(jvmOptions).userDataId(userDataId)
                     .fsRoot(fsRoot).retentionTime(overrideRetentionTime).keyPairName(keyPairName).networkId(networkId).securityGroups(securityGroups)
                     .launcherFactory(lf).availabilityZone(availabilityZone).build()
             ;

--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
@@ -125,7 +125,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
                 lf = LauncherFactory.JNLP.JNLP;
             }
 
-            slaveOptions = SlaveOptions.builder().bootSource(new BootSource.Image(imageId)).hardwareId(hardwareId).numExecutors(Integer.getInteger(numExecutors)).jvmOptions(jvmOptions).userDataId(userDataId)
+            slaveOptions = SlaveOptions.builder().bootSource(new BootSource.Image(imageId, false, 0)).hardwareId(hardwareId).numExecutors(Integer.getInteger(numExecutors)).jvmOptions(jvmOptions).userDataId(userDataId)
                     .fsRoot(fsRoot).retentionTime(overrideRetentionTime).keyPairName(keyPairName).networkId(networkId).securityGroups(securityGroups)
                     .launcherFactory(lf).availabilityZone(availabilityZone).build()
             ;

--- a/src/main/java/jenkins/plugins/openstack/compute/SlaveOptions.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/SlaveOptions.java
@@ -195,7 +195,7 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
 
     private Object readResolve() {
         if (bootSource == null && imageId != null) {
-            bootSource = new BootSource.Image(imageId, false, 0);
+            bootSource = new BootSource.Image(imageId, null);
         }
         imageId = null;
         return this;

--- a/src/main/java/jenkins/plugins/openstack/compute/SlaveOptions.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/SlaveOptions.java
@@ -195,7 +195,7 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
 
     private Object readResolve() {
         if (bootSource == null && imageId != null) {
-            bootSource = new BootSource.Image(imageId);
+            bootSource = new BootSource.Image(imageId, false, 0);
         }
         imageId = null;
         return this;

--- a/src/main/java/jenkins/plugins/openstack/compute/slaveopts/BootSource.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/slaveopts/BootSource.java
@@ -208,24 +208,17 @@ public abstract class BootSource extends AbstractDescribableImpl<BootSource> imp
         private static final long serialVersionUID = -8309975034351235331L;
 
         private final @Nonnull String name;
-        private final @Nonnull Boolean createNewVolume;
         private final @Nonnull Integer volumeSize;
 
         @DataBoundConstructor
-        public Image(@Nonnull String name, @Nonnull Boolean createNewVolume, @Nonnull Integer volumeSize) {
+        public Image(@Nonnull String name, @Nonnull OptionalVolumeSize createNewVolume) {
             this.name = name;
-            this.createNewVolume = createNewVolume;
-            this.volumeSize = volumeSize;
+            this.volumeSize = (createNewVolume != null) ? createNewVolume.volumeSize : null;
         }
 
         @Nonnull
         public String getName() {
             return name;
-        }
-
-        @Nonnull
-        public Boolean getCreateNewVolume() {
-            return createNewVolume;
         }
 
         @Nonnull
@@ -239,7 +232,7 @@ public abstract class BootSource extends AbstractDescribableImpl<BootSource> imp
             final List<String> matchingIds = getDescriptor().findMatchingIds(os, name);
             final String id = selectIdFromListAndLogProblems(matchingIds, name, "Images");
 
-            if (createNewVolume) {
+            if (volumeSize != null && volumeSize > 0) {
               final BlockDeviceMappingBuilder volumeBuilder = Builders.blockDeviceMapping()
                       .sourceType(BDMSourceType.IMAGE)
                       .destinationType(BDMDestType.VOLUME)
@@ -271,6 +264,15 @@ public abstract class BootSource extends AbstractDescribableImpl<BootSource> imp
         @Override
         public int hashCode() {
             return name.hashCode();
+        }
+
+        public static class OptionalVolumeSize {
+            private Integer volumeSize;
+
+            @DataBoundConstructor
+            public OptionalVolumeSize(Integer volumeSize) {
+                this.volumeSize = volumeSize;
+            }
         }
 
         @Extension

--- a/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/Image/config.jelly
+++ b/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/Image/config.jelly
@@ -3,4 +3,10 @@
     <f:entry title="Name" field="name">
         <f:select/>
     </f:entry>
+    <f:entry title="Create New Volume" field="createNewVolume">
+        <f:booleanRadio />
+    </f:entry>
+    <f:entry title="Volume Size (GB)" field="volumeSize">
+        <f:number/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/Image/config.jelly
+++ b/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/Image/config.jelly
@@ -3,10 +3,9 @@
     <f:entry title="Name" field="name">
         <f:select/>
     </f:entry>
-    <f:entry title="Create New Volume" field="createNewVolume">
-        <f:booleanRadio />
-    </f:entry>
-    <f:entry title="Volume Size (GB)" field="volumeSize">
-        <f:number/>
-    </f:entry>
+    <f:optionalBlock name="createNewVolume" title="Create New Volume" checked="${instance.volumeSize != null}">
+        <f:entry title="Volume Size (GB)" field="volumeSize">
+            <f:number/>
+        </f:entry>
+    </f:optionalBlock>
 </j:jelly>

--- a/src/test/java/jenkins/plugins/openstack/PluginTestRule.java
+++ b/src/test/java/jenkins/plugins/openstack/PluginTestRule.java
@@ -128,7 +128,7 @@ public final class PluginTestRule extends JenkinsRule {
 
         // Use some real-looking values preserving defaults to make sure plugin works with them
         return JCloudsCloud.DescriptorImpl.getDefaultOptions().getBuilder()
-                .bootSource(new BootSource.Image("dummyImageId", false, 0))
+                .bootSource(new BootSource.Image("dummyImageId", null))
                 .hardwareId("dummyHardwareId")
                 .networkId("dummyNetworkId")
                 .userDataId("dummyUserDataId")

--- a/src/test/java/jenkins/plugins/openstack/PluginTestRule.java
+++ b/src/test/java/jenkins/plugins/openstack/PluginTestRule.java
@@ -128,7 +128,7 @@ public final class PluginTestRule extends JenkinsRule {
 
         // Use some real-looking values preserving defaults to make sure plugin works with them
         return JCloudsCloud.DescriptorImpl.getDefaultOptions().getBuilder()
-                .bootSource(new BootSource.Image("dummyImageId"))
+                .bootSource(new BootSource.Image("dummyImageId", false, 0))
                 .hardwareId("dummyHardwareId")
                 .networkId("dummyNetworkId")
                 .userDataId("dummyUserDataId")

--- a/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudTest.java
@@ -142,7 +142,7 @@ public class JCloudsCloudTest {
         String openstackAuth = j.dummyCredential();
 
         JCloudsSlaveTemplate template = new JCloudsSlaveTemplate("template", "label", new SlaveOptions(
-                new BootSource.Image("iid", false, 0), "hw", "nw", "ud", 1, "public", "sg", "az", 2, "kp", 3, "jvmo", "fsRoot", LauncherFactory.JNLP.JNLP, 4
+                new BootSource.Image("iid", null), "hw", "nw", "ud", 1, "public", "sg", "az", 2, "kp", 3, "jvmo", "fsRoot", LauncherFactory.JNLP.JNLP, 4
         ));
         JCloudsCloud cloud = new JCloudsCloud("openstack", "endPointUrl", false,"zone", new SlaveOptions(
                 new BootSource.VolumeSnapshot("vsid"), "HW", "NW", "UD", 6, null, "SG", "AZ", 7, "KP", 8, "JVMO", "FSrOOT", new LauncherFactory.SSH("cid"), 9

--- a/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudTest.java
@@ -142,7 +142,7 @@ public class JCloudsCloudTest {
         String openstackAuth = j.dummyCredential();
 
         JCloudsSlaveTemplate template = new JCloudsSlaveTemplate("template", "label", new SlaveOptions(
-                new BootSource.Image("iid"), "hw", "nw", "ud", 1, "public", "sg", "az", 2, "kp", 3, "jvmo", "fsRoot", LauncherFactory.JNLP.JNLP, 4
+                new BootSource.Image("iid", false, 0), "hw", "nw", "ud", 1, "public", "sg", "az", 2, "kp", 3, "jvmo", "fsRoot", LauncherFactory.JNLP.JNLP, 4
         ));
         JCloudsCloud cloud = new JCloudsCloud("openstack", "endPointUrl", false,"zone", new SlaveOptions(
                 new BootSource.VolumeSnapshot("vsid"), "HW", "NW", "UD", 6, null, "SG", "AZ", 7, "KP", 8, "JVMO", "FSrOOT", new LauncherFactory.SSH("cid"), 9

--- a/src/test/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplateTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplateTest.java
@@ -87,7 +87,7 @@ public class JCloudsSlaveTemplateTest {
     @Test
     public void eraseDefaults() throws Exception {
         SlaveOptions cloudOpts = PluginTestRule.dummySlaveOptions(); // Make sure nothing collides with defaults
-        SlaveOptions templateOpts = cloudOpts.getBuilder().bootSource(new BootSource.Image("id")).availabilityZone("other").build();
+        SlaveOptions templateOpts = cloudOpts.getBuilder().bootSource(new BootSource.Image("id", false, 0)).availabilityZone("other").build();
         assertEquals(cloudOpts.getHardwareId(), templateOpts.getHardwareId());
 
         JCloudsSlaveTemplate template = new JCloudsSlaveTemplate(
@@ -102,7 +102,7 @@ public class JCloudsSlaveTemplateTest {
         );
 
         assertEquals(cloudOpts, cloud.getRawSlaveOptions());
-        assertEquals(SlaveOptions.builder().bootSource(new BootSource.Image("id")).availabilityZone("other").build(), template.getRawSlaveOptions());
+        assertEquals(SlaveOptions.builder().bootSource(new BootSource.Image("id", false, 0)).availabilityZone("other").build(), template.getRawSlaveOptions());
     }
 
     @Test

--- a/src/test/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplateTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplateTest.java
@@ -87,7 +87,7 @@ public class JCloudsSlaveTemplateTest {
     @Test
     public void eraseDefaults() throws Exception {
         SlaveOptions cloudOpts = PluginTestRule.dummySlaveOptions(); // Make sure nothing collides with defaults
-        SlaveOptions templateOpts = cloudOpts.getBuilder().bootSource(new BootSource.Image("id", false, 0)).availabilityZone("other").build();
+        SlaveOptions templateOpts = cloudOpts.getBuilder().bootSource(new BootSource.Image("id", null)).availabilityZone("other").build();
         assertEquals(cloudOpts.getHardwareId(), templateOpts.getHardwareId());
 
         JCloudsSlaveTemplate template = new JCloudsSlaveTemplate(
@@ -102,7 +102,7 @@ public class JCloudsSlaveTemplateTest {
         );
 
         assertEquals(cloudOpts, cloud.getRawSlaveOptions());
-        assertEquals(SlaveOptions.builder().bootSource(new BootSource.Image("id", false, 0)).availabilityZone("other").build(), template.getRawSlaveOptions());
+        assertEquals(SlaveOptions.builder().bootSource(new BootSource.Image("id", null)).availabilityZone("other").build(), template.getRawSlaveOptions());
     }
 
     @Test

--- a/src/test/java/jenkins/plugins/openstack/compute/ProvisioningTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/ProvisioningTest.java
@@ -287,7 +287,7 @@ public class ProvisioningTest {
 
     @Test
     public void allowToUseImageNameAsWellAsId() throws Exception {
-        SlaveOptions opts = j.defaultSlaveOptions().getBuilder().bootSource(new BootSource.Image("image-id")).build();
+        SlaveOptions opts = j.defaultSlaveOptions().getBuilder().bootSource(new BootSource.Image("image-id", false, 0)).build();
         JCloudsCloud cloud = j.configureSlaveLaunching(j.dummyCloud(j.dummySlaveTemplate(opts, "label")));
 
         Openstack os = cloud.getOpenstack();

--- a/src/test/java/jenkins/plugins/openstack/compute/ProvisioningTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/ProvisioningTest.java
@@ -287,7 +287,7 @@ public class ProvisioningTest {
 
     @Test
     public void allowToUseImageNameAsWellAsId() throws Exception {
-        SlaveOptions opts = j.defaultSlaveOptions().getBuilder().bootSource(new BootSource.Image("image-id", false, 0)).build();
+        SlaveOptions opts = j.defaultSlaveOptions().getBuilder().bootSource(new BootSource.Image("image-id", null)).build();
         JCloudsCloud cloud = j.configureSlaveLaunching(j.dummyCloud(j.dummySlaveTemplate(opts, "label")));
 
         Openstack os = cloud.getOpenstack();

--- a/src/test/java/jenkins/plugins/openstack/compute/SlaveOptionsTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/SlaveOptionsTest.java
@@ -34,7 +34,7 @@ public class SlaveOptionsTest {
         assertEquals(1, (int) unmodified.getRetentionTime());
 
         SlaveOptions override = SlaveOptions.builder()
-                .bootSource(new BootSource.Image("iid", false, 0))
+                .bootSource(new BootSource.Image("iid", null))
                 .hardwareId("HW")
                 .networkId("NW")
                 .userDataId("UD")
@@ -53,7 +53,7 @@ public class SlaveOptionsTest {
         ;
         SlaveOptions overridden = PluginTestRule.dummySlaveOptions().override(override);
 
-        assertEquals(new BootSource.Image("iid", false, 0), overridden.getBootSource());
+        assertEquals(new BootSource.Image("iid", null), overridden.getBootSource());
         assertEquals("HW", overridden.getHardwareId());
         assertEquals("NW", overridden.getNetworkId());
         assertEquals("UD", overridden.getUserDataId());
@@ -72,8 +72,8 @@ public class SlaveOptionsTest {
 
     @Test
     public void eraseDefaults() {
-        SlaveOptions defaults = SlaveOptions.builder().bootSource(new BootSource.Image("ID", false, 0)).hardwareId("hw").networkId(null).floatingIpPool("a").build();
-        SlaveOptions configured = SlaveOptions.builder().bootSource(new BootSource.Image("ID", false, 0)).hardwareId("hw").networkId("MW").floatingIpPool("A").build();
+        SlaveOptions defaults = SlaveOptions.builder().bootSource(new BootSource.Image("ID", null)).hardwareId("hw").networkId(null).floatingIpPool("a").build();
+        SlaveOptions configured = SlaveOptions.builder().bootSource(new BootSource.Image("ID", null)).hardwareId("hw").networkId("MW").floatingIpPool("A").build();
 
         SlaveOptions actual = configured.eraseDefaults(defaults);
 

--- a/src/test/java/jenkins/plugins/openstack/compute/SlaveOptionsTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/SlaveOptionsTest.java
@@ -34,7 +34,7 @@ public class SlaveOptionsTest {
         assertEquals(1, (int) unmodified.getRetentionTime());
 
         SlaveOptions override = SlaveOptions.builder()
-                .bootSource(new BootSource.Image("iid"))
+                .bootSource(new BootSource.Image("iid", false, 0))
                 .hardwareId("HW")
                 .networkId("NW")
                 .userDataId("UD")
@@ -53,7 +53,7 @@ public class SlaveOptionsTest {
         ;
         SlaveOptions overridden = PluginTestRule.dummySlaveOptions().override(override);
 
-        assertEquals(new BootSource.Image("iid"), overridden.getBootSource());
+        assertEquals(new BootSource.Image("iid", false, 0), overridden.getBootSource());
         assertEquals("HW", overridden.getHardwareId());
         assertEquals("NW", overridden.getNetworkId());
         assertEquals("UD", overridden.getUserDataId());
@@ -72,8 +72,8 @@ public class SlaveOptionsTest {
 
     @Test
     public void eraseDefaults() {
-        SlaveOptions defaults = SlaveOptions.builder().bootSource(new BootSource.Image("ID")).hardwareId("hw").networkId(null).floatingIpPool("a").build();
-        SlaveOptions configured = SlaveOptions.builder().bootSource(new BootSource.Image("ID")).hardwareId("hw").networkId("MW").floatingIpPool("A").build();
+        SlaveOptions defaults = SlaveOptions.builder().bootSource(new BootSource.Image("ID", false, 0)).hardwareId("hw").networkId(null).floatingIpPool("a").build();
+        SlaveOptions configured = SlaveOptions.builder().bootSource(new BootSource.Image("ID", false, 0)).hardwareId("hw").networkId("MW").floatingIpPool("A").build();
 
         SlaveOptions actual = configured.eraseDefaults(defaults);
 


### PR DESCRIPTION
This patch allows the creation of volumes by Nova using block device mapping with custom sizes.

This is very useful if you have an instance type with root_gb=0 and you need to control the size of the root volume.

Note that this requires the Cinder block storage service to be active in the cloud.  I tested this locally and it works and I'm very much an 'ok' Java developer so please let me know what you'd like me to add onto this.

I'm hoping to get this merged so I'll be quick to turn around fixes.  The code is pretty straight forward.