### PR TITLE
Show OpenStack Server details in Jenkins WebUI computer page

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsComputer.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsComputer.java
@@ -95,6 +95,7 @@ public class JCloudsComputer extends AbstractCloudComputer<JCloudsSlave> impleme
         final JCloudsSlave node = getNode();
         if (node != null) {
             final SlaveOptions slaveOptions = node.getSlaveOptions();
+            putIfNotNullOrEmpty(result, "ServerId", node.getServerId());
             putIfNotNullOrEmpty(result, "HardwareId", slaveOptions.getHardwareId());
             putIfNotNullOrEmpty(result, "NetworkId", slaveOptions.getNetworkId());
             putIfNotNullOrEmpty(result, "FloatingIpPool", slaveOptions.getFloatingIpPool());

--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsComputer.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsComputer.java
@@ -65,62 +65,6 @@ public class JCloudsComputer extends AbstractCloudComputer<JCloudsSlave> impleme
         return super.getNode();
     }
 
-    /**
-     * Gets the metadata settings that were provided to Openstack
-     * when the slave was created by the plugin, excluding any empty values.
-     * 
-     * @return A Map of metadata key to metadata value. This will not be null.
-     */
-    public Map<String, String> getOpenstackMetaData() {
-        final Map<String, String> result = new LinkedHashMap<>();
-        final JCloudsSlave node = getNode();
-        if (node != null) {
-            final Map<String, String> metaData = node.getOpenstackMetaData();
-            for (Map.Entry<String, String> entry : metaData.entrySet()) {
-                putIfNotNullOrEmpty(result, entry.getKey(), entry.getValue());
-            }
-        }
-        return result;
-    }
-
-    /**
-     * Gets most of the Server settings that were provided to Openstack
-     * when the slave was created by the plugin.
-     * Not all settings are interesting and any that are empty/null are omitted.
-     * 
-     * @return A Map of metadata key to metadata value. This will not be null.
-     */
-    public Map<String, String> getOpenstackSlaveOptions() {
-        final Map<String, String> result = new LinkedHashMap<>();
-        final JCloudsSlave node = getNode();
-        if (node != null) {
-            final SlaveOptions slaveOptions = node.getSlaveOptions();
-            putIfNotNullOrEmpty(result, "ServerId", node.getServerId());
-            putIfNotNullOrEmpty(result, "HardwareId", slaveOptions.getHardwareId());
-            putIfNotNullOrEmpty(result, "NetworkId", slaveOptions.getNetworkId());
-            putIfNotNullOrEmpty(result, "FloatingIpPool", slaveOptions.getFloatingIpPool());
-            putIfNotNullOrEmpty(result, "SecurityGroups", slaveOptions.getSecurityGroups());
-            putIfNotNullOrEmpty(result, "AvailabilityZone", slaveOptions.getAvailabilityZone());
-            putIfNotNullOrEmpty(result, "StartTimeout", slaveOptions.getStartTimeout());
-            putIfNotNullOrEmpty(result, "KeyPairName", slaveOptions.getKeyPairName());
-            final Object launcherFactory = slaveOptions.getLauncherFactory();
-            putIfNotNullOrEmpty(result, "LauncherFactory",
-                    launcherFactory == null ? null : launcherFactory.getClass().getSimpleName());
-            putIfNotNullOrEmpty(result, "JvmOptions", slaveOptions.getJvmOptions());
-        }
-        return result;
-    }
-
-    private static void putIfNotNullOrEmpty(final Map<String, String> mapToBeAddedTo, final String fieldName,
-            final Object fieldValue) {
-        if (fieldValue != null) {
-            final String valueString = fieldValue.toString();
-            if (!valueString.trim().isEmpty()) {
-                mapToBeAddedTo.put(fieldName, valueString);
-            }
-        }
-    }
-
     @Override
     public @Nonnull ProvisioningActivity.Id getId() {
         return provisioningId;

--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsComputer.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsComputer.java
@@ -27,9 +27,7 @@ import javax.annotation.Nonnull;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.logging.Logger;
 
 /**

--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlave.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlave.java
@@ -36,7 +36,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;

--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlave.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlave.java
@@ -26,7 +26,9 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.TreeMap;
 import java.util.logging.Logger;
 
 /**
@@ -40,6 +42,7 @@ public class JCloudsSlave extends AbstractCloudSlave implements TrackedItem {
     // Full/effective options
     private /*final*/ @Nonnull SlaveOptions options;
     private final @Nonnull ProvisioningActivity.Id provisioningId;
+    private final @CheckForNull Map<String, String> openstackMetaData;
 
     private /*final*/ @Nonnull String nodeId;
 
@@ -72,6 +75,12 @@ public class JCloudsSlave extends AbstractCloudSlave implements TrackedItem {
         this.provisioningId = id;
         this.options = slaveOptions;
         this.nodeId = metadata.getId();
+        final Map<String, String> instanceMetaData = metadata.getMetadata();
+        if (instanceMetaData != null && !instanceMetaData.isEmpty()) {
+            this.openstackMetaData = new TreeMap<>(instanceMetaData);
+        } else {
+            this.openstackMetaData = null;
+        }
         setLauncher(new JCloudsLauncher(getLauncherFactory().createLauncher(this)));
     }
 
@@ -112,6 +121,16 @@ public class JCloudsSlave extends AbstractCloudSlave implements TrackedItem {
         nodeId =  nodeId.replaceFirst(".*/", ""); // Remove region prefix
 
         return this;
+    }
+
+    /**
+     * Get all the metadata settings that the plugin wrote into the OpenStack
+     * Server's metadata.
+     * 
+     * @return A Map of metadata key to metadata value. This will not be null.
+     */
+    public @Nonnull Map<String, String> getOpenstackMetaData() {
+        return openstackMetaData == null ? new TreeMap<>() : openstackMetaData;
     }
 
     /**

--- a/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
@@ -397,6 +397,19 @@ public class Openstack {
     }
 
     /**
+     * Gets the description of a {@link VolumeSnapshot}. This will be visible
+     * if a user looks at volume snapshots using the OpenStack command-line or WebUI
+     * and may well contain useful information.
+     *
+     * @param volumeSnapshotId
+     *            The ID of the volume snapshot whose description is to be retrieved.
+     * @return The description string.
+     */
+    public String getVolumeSnapshotDescription(String volumeSnapshotId) {
+        return clientProvider.get().blockStorage().snapshots().get(volumeSnapshotId).getDescription();
+    }
+
+    /**
      * Sets the name and description of a {@link Volume}. These will be visible
      * if a user looks at volumes using the OpenStack command-line or WebUI.
      *

--- a/src/main/java/jenkins/plugins/openstack/compute/slaveopts/BootSource.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/slaveopts/BootSource.java
@@ -359,6 +359,7 @@ public abstract class BootSource extends AbstractDescribableImpl<BootSource> imp
     public static final class VolumeSnapshot extends BootSource {
         private static final long serialVersionUID = 1629434277902240395L;
         private static final String OPENSTACK_BOOTSOURCE_VOLUMESNAPSHOT_ID_KEY = "jenkins-boot-volumesnapshot-id";
+        private static final String OPENSTACK_BOOTSOURCE_VOLUMESNAPSHOT_DESC_KEY = "jenkins-boot-volumesnapshot-description";
 
         private final @Nonnull String name;
 
@@ -377,6 +378,7 @@ public abstract class BootSource extends AbstractDescribableImpl<BootSource> imp
             super.setServerBootSource(builder, os);
             final List<String> matchingIds = getDescriptor().findMatchingIds(os, name);
             final String id = selectIdFromListAndLogProblems(matchingIds, name, "VolumeSnapshots");
+            final String volumeSnapshotDescription = os.getVolumeSnapshotDescription(id);
             final BlockDeviceMappingBuilder volumeBuilder = Builders.blockDeviceMapping()
                     .sourceType(BDMSourceType.SNAPSHOT)
                     .destinationType(BDMDestType.VOLUME)
@@ -385,6 +387,7 @@ public abstract class BootSource extends AbstractDescribableImpl<BootSource> imp
                     .bootIndex(0);
             builder.blockDevice(volumeBuilder.build());
             builder.addMetadataItem(OPENSTACK_BOOTSOURCE_VOLUMESNAPSHOT_ID_KEY, id);
+            builder.addMetadataItem(OPENSTACK_BOOTSOURCE_VOLUMESNAPSHOT_DESC_KEY, volumeSnapshotDescription);
         }
 
         @Override

--- a/src/main/resources/jenkins/plugins/openstack/compute/JCloudsComputer/main.jelly
+++ b/src/main/resources/jenkins/plugins/openstack/compute/JCloudsComputer/main.jelly
@@ -1,20 +1,33 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
 
-  <h2>OpenStack server metadata</h2>
-  <dl>
-    <j:forEach var="entry" items="${it.getOpenstackMetaData().entrySet()}">
-      <dt>${entry.getKey()}:</dt>
-      <dd><tt>${entry.getValue()}</tt></dd>
-    </j:forEach>
-  </dl>
-
-  <h2>OpenStack server specifications</h2>
-  <dl>
-    <j:forEach var="entry" items="${it.getOpenstackSlaveOptions().entrySet()}">
-      <dt>${entry.getKey()}:</dt>
-      <dd><tt>${entry.getValue()}</tt></dd>
-    </j:forEach>
-  </dl>
+  <h2>OpenStack details</h2>
+  <table class="pane sortable bigtable">
+    <j:choose>
+      <j:when test="${empty(it.openstackMetaData) and empty(it.openstackSlaveOptions)}">
+        <tr><td>
+          ${%No data}
+        </td></tr>
+      </j:when>
+      <j:otherwise>
+        <tr>
+          <th class="pane-header" initialSortDir="down">${%Name}</th>
+          <th class="pane-header">${%Value}</th>
+        </tr>
+        <j:forEach var="e" items="${it.openstackMetaData.entrySet()}">
+          <tr>
+            <td class="pane"><st:out value="${e.key}"/></td>
+            <td class="pane"><st:out value="${e.value}"/></td>
+          </tr>
+        </j:forEach>
+        <j:forEach var="e" items="${it.openstackSlaveOptions.entrySet()}">
+          <tr>
+            <td class="pane"><st:out value="${e.key}"/></td>
+            <td class="pane"><st:out value="${e.value}"/></td>
+          </tr>
+        </j:forEach>
+      </j:otherwise>
+    </j:choose>
+  </table>
 
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/openstack/compute/JCloudsComputer/main.jelly
+++ b/src/main/resources/jenkins/plugins/openstack/compute/JCloudsComputer/main.jelly
@@ -1,0 +1,20 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+
+  <h2>OpenStack server metadata</h2>
+  <dl>
+    <j:forEach var="entry" items="${it.getOpenstackMetaData().entrySet()}">
+      <dt>${entry.getKey()}:</dt>
+      <dd><tt>${entry.getValue()}</tt></dd>
+    </j:forEach>
+  </dl>
+
+  <h2>OpenStack server specifications</h2>
+  <dl>
+    <j:forEach var="entry" items="${it.getOpenstackSlaveOptions().entrySet()}">
+      <dt>${entry.getKey()}:</dt>
+      <dd><tt>${entry.getValue()}</tt></dd>
+    </j:forEach>
+  </dl>
+
+</j:jelly>

--- a/src/main/resources/jenkins/plugins/openstack/compute/JCloudsComputer/main.jelly
+++ b/src/main/resources/jenkins/plugins/openstack/compute/JCloudsComputer/main.jelly
@@ -2,32 +2,39 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
 
   <h2>OpenStack details</h2>
-  <table class="pane sortable bigtable">
-    <j:choose>
-      <j:when test="${empty(it.openstackMetaData) and empty(it.openstackSlaveOptions)}">
+  <j:choose>
+    <j:when test="${it.node==null}">
+      <table class="pane sortable bigtable">
         <tr><td>
           ${%No data}
         </td></tr>
-      </j:when>
-      <j:otherwise>
+      </table>
+    </j:when>
+    <j:otherwise>
+      <j:choose>
+        <j:when test="${empty(it.node.liveOpenstackServerDetails)}">
+          <b>${%Warning}:</b> ${%Live data unavailable.}
+        </j:when>
+      </j:choose>
+      <table class="pane sortable bigtable">
         <tr>
           <th class="pane-header" initialSortDir="down">${%Name}</th>
           <th class="pane-header">${%Value}</th>
         </tr>
-        <j:forEach var="e" items="${it.openstackMetaData.entrySet()}">
+        <j:forEach var="e" items="${it.node.openstackSlaveData.entrySet()}">
           <tr>
             <td class="pane"><st:out value="${e.key}"/></td>
             <td class="pane"><st:out value="${e.value}"/></td>
           </tr>
         </j:forEach>
-        <j:forEach var="e" items="${it.openstackSlaveOptions.entrySet()}">
+        <j:forEach var="e" items="${it.node.liveOpenstackServerDetails.entrySet()}">
           <tr>
             <td class="pane"><st:out value="${e.key}"/></td>
             <td class="pane"><st:out value="${e.value}"/></td>
           </tr>
         </j:forEach>
-      </j:otherwise>
-    </j:choose>
-  </table>
+      </table>
+    </j:otherwise>
+  </j:choose>
 
 </j:jelly>


### PR DESCRIPTION
The OpenStack plugin copes with configuration ambiguity by choosing the newest match.
In situations where new things are being added/changed while new servers are starting, it isn't clear which Jenkins slaves started from the "old" settings and which started from the "new" settings.
This enhancement
* Adds metadata to the OpenStack VM so one can see "at a glance" what it was booted from
* Displays that metadata, and other OpenStack VM settings, on the Jenkins .../computer/myAgentName page.