### PR TITLE
Allow underscores to be used in template-name

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
@@ -442,7 +442,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 
     @Extension
     public static final class DescriptorImpl extends Descriptor<JCloudsSlaveTemplate> {
-        private static final Pattern NAME_PATTERN = Pattern.compile("^[a-z0-9][-a-zA-Z0-9]{0,79}$");
+        private static final Pattern NAME_PATTERN = Pattern.compile("^[a-z0-9][-_a-zA-Z0-9]{0,79}$");
 
         @Override
         public String getDisplayName() {


### PR DESCRIPTION
The underscore _ character used to be a valid character. The regex
should allow the use of this character.
