### PR TITLE
Enable glance V2 support and deprecate glance V1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
         <guava.version>18.0</guava.version> <!-- version compatible with openstack4j -->
         <jsr305.version>1.3.9</jsr305.version>
-        <openstack4j.version>3.1.0</openstack4j.version>
+        <openstack4j.version>3.1.1-SNAPSHOT</openstack4j.version>
     </properties>
 
     <developers>
@@ -217,6 +217,11 @@
    </distributionManagement>
 
     <repositories>
+        <repository>
+           <id>st-snapshots</id>
+           <name>sonatype-snapshots</name>
+           <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </repository>
         <repository>
             <id>repo.jenkins-ci.org</id>
             <url>http://repo.jenkins-ci.org/public/</url>

--- a/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
@@ -81,7 +81,7 @@ import org.openstack4j.model.compute.builder.ServerCreateBuilder;
 import org.openstack4j.model.compute.ext.AvailabilityZone;
 import org.openstack4j.model.identity.v2.Access;
 import org.openstack4j.model.identity.v3.Token;
-import org.openstack4j.model.image.Image;
+import org.openstack4j.model.image.v2.Image;
 import org.openstack4j.model.network.NetFloatingIP;
 import org.openstack4j.model.network.Network;
 import org.openstack4j.model.storage.block.Volume;
@@ -204,7 +204,7 @@ public class Openstack {
      *         creation date.
      */
     public @Nonnull Map<String, Collection<Image>> getImages() {
-        final List<? extends Image> list = clientProvider.get().images().listAll();
+        final List<? extends Image> list = clientProvider.get().imagesV2().list();
         final TreeMultimap<String, Image> set = TreeMultimap.create(String.CASE_INSENSITIVE_ORDER, IMAGE_DATE_COMPARATOR);
         for (Image o : list) {
             final String name = Util.fixNull(o.getName());
@@ -353,11 +353,11 @@ public class Openstack {
         final Map<String, String> query = new HashMap<>(2);
         query.put("name", nameOrId);
         query.put("status", "active");
-        final List<? extends Image> findByName = clientProvider.get().images().listAll(query);
+        final List<? extends Image> findByName = clientProvider.get().imagesV2().list(query);
         sortedObjects.addAll(findByName);
         if (nameOrId.matches("[0-9a-f-]{36}")) {
-            final Image findById = clientProvider.get().images().get(nameOrId);
-            if (findById != null && findById.getStatus() == Image.Status.ACTIVE) {
+            final Image findById = clientProvider.get().imagesV2().get(nameOrId);
+            if (findById != null && findById.getStatus() == Image.ImageStatus.ACTIVE) {
                 sortedObjects.add(findById);
             }
         }

--- a/src/test/java/jenkins/plugins/openstack/compute/internal/OpenstackTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/internal/OpenstackTest.java
@@ -18,7 +18,7 @@ import org.openstack4j.api.OSClient;
 import org.openstack4j.api.compute.ComputeFloatingIPService;
 import org.openstack4j.api.compute.ext.ZoneService;
 import org.openstack4j.api.exceptions.ClientResponseException;
-import org.openstack4j.api.image.ImageService;
+import org.openstack4j.api.image.v2.ImageService;
 import org.openstack4j.api.storage.BlockVolumeSnapshotService;
 import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.compute.Fault;
@@ -26,7 +26,7 @@ import org.openstack4j.model.compute.FloatingIP;
 import org.openstack4j.model.compute.Server;
 import org.openstack4j.model.compute.builder.ServerCreateBuilder;
 import org.openstack4j.model.compute.ext.AvailabilityZone;
-import org.openstack4j.model.image.Image;
+import org.openstack4j.model.image.v2.Image;
 import org.openstack4j.model.storage.block.Volume;
 import org.openstack4j.model.storage.block.VolumeSnapshot;
 import org.openstack4j.openstack.compute.domain.NovaFloatingIP;
@@ -72,7 +72,7 @@ public class OpenstackTest {
         final List images = Arrays.asList(mockImageNamedBar1, mockImageWithNullName, mockImageNamedBar2,
                 mockImageNamedFoo, mockImageNamedBar3);
         final OSClient mockClient = mock(OSClient.class, RETURNS_DEEP_STUBS);
-        when(mockClient.images().listAll()).thenReturn(images);
+        when(mockClient.imagesV2().list()).thenReturn(images);
         final Collection<Image> images0 = new ArrayList<>(
                 Arrays.asList(mockImageNamedBar2, mockImageNamedBar3, mockImageNamedBar1));
         final Collection<Image> images1 = new ArrayList<>(Arrays.asList(mockImageNamedFoo));
@@ -170,11 +170,11 @@ public class OpenstackTest {
         when(mockImageNamedBar3.getCreatedAt()).thenReturn(new Date(1000));
         final ImageService mockIS = mock(ImageService.class);
         final List images = Arrays.asList(mockImageNamedBar1, mockImageNamedBar2, mockImageNamedBar3);
-        when(mockIS.listAll(anyMapOf(String.class, String.class))).thenReturn(images);
+        when(mockIS.list(anyMapOf(String.class, String.class))).thenReturn(images);
         final ArrayList<String> expected = new ArrayList<>(
                 Arrays.asList("mockImageNamedBar2Id", "mockImageNamedBar3Id", "mockImageNamedBar1Id"));
         final OSClient mockClient = mock(OSClient.class);
-        when(mockClient.images()).thenReturn(mockIS);
+        when(mockClient.imagesV2()).thenReturn(mockIS);
 
         final Openstack instance = new Openstack(mockClient);
         final List<String> actual = instance.getImageIdsFor("Bar");
@@ -182,7 +182,7 @@ public class OpenstackTest {
         final Map<String, String> expectedFilteringParams = new HashMap<>(2);
         expectedFilteringParams.put("name", "Bar");
         expectedFilteringParams.put("status", "active");
-        verify(mockIS).listAll(argThat(equalTo(expectedFilteringParams)));
+        verify(mockIS).list(argThat(equalTo(expectedFilteringParams)));
         verifyNoMoreInteractions(mockIS);
         assertThat(new ArrayList<>(actual), equalTo(expected));
     }
@@ -190,9 +190,9 @@ public class OpenstackTest {
     @Test
     public void getImageIdsForGivenUnknownThenReturnsEmpty() {
         final ImageService mockIS = mock(ImageService.class);
-        when(mockIS.listAll(anyMapOf(String.class, String.class))).thenReturn(Collections.EMPTY_LIST);
+        when(mockIS.list(anyMapOf(String.class, String.class))).thenReturn(Collections.EMPTY_LIST);
         final OSClient mockClient = mock(OSClient.class);
-        when(mockClient.images()).thenReturn(mockIS);
+        when(mockClient.imagesV2()).thenReturn(mockIS);
         final ArrayList<String> expected = new ArrayList<>();
 
         final Openstack instance = new Openstack(mockClient);
@@ -201,7 +201,7 @@ public class OpenstackTest {
         final Map<String, String> expectedFilteringParams = new HashMap<>(2);
         expectedFilteringParams.put("name", "NameNotFound");
         expectedFilteringParams.put("status", "active");
-        verify(mockIS).listAll(argThat(equalTo(expectedFilteringParams)));
+        verify(mockIS).list(argThat(equalTo(expectedFilteringParams)));
         verifyNoMoreInteractions(mockIS);
         assertThat(new ArrayList<>(actual), equalTo(expected));
     }
@@ -212,18 +212,18 @@ public class OpenstackTest {
         final String imageId = "cfd083b4-2422-4c5f-bf61-d975709375ab";
         when(mockImageNamedFoo.getId()).thenReturn(imageId);
         when(mockImageNamedFoo.getName()).thenReturn("Foo");
-        when(mockImageNamedFoo.getStatus()).thenReturn(Image.Status.ACTIVE);
+        when(mockImageNamedFoo.getStatus()).thenReturn(Image.ImageStatus.ACTIVE);
         final ImageService mockIS = mock(ImageService.class);
-        when(mockIS.listAll(anyMapOf(String.class, String.class))).thenReturn(Collections.EMPTY_LIST);
+        when(mockIS.list(anyMapOf(String.class, String.class))).thenReturn(Collections.EMPTY_LIST);
         when(mockIS.get(imageId)).thenReturn(mockImageNamedFoo);
         final OSClient mockClient = mock(OSClient.class);
-        when(mockClient.images()).thenReturn(mockIS);
+        when(mockClient.imagesV2()).thenReturn(mockIS);
         final ArrayList<String> expected = new ArrayList<>(Arrays.asList(mockImageNamedFoo.getId()));
 
         final Openstack instance = new Openstack(mockClient);
         final List<String> actual = instance.getImageIdsFor(imageId);
 
-        verify(mockIS).listAll(anyMapOf(String.class, String.class));
+        verify(mockIS).list(anyMapOf(String.class, String.class));
         verify(mockIS).get(imageId);
         verifyNoMoreInteractions(mockIS);
         assertThat(new ArrayList<>(actual), equalTo(expected));

--- a/src/test/java/jenkins/plugins/openstack/compute/slaveopts/BootSourceTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/slaveopts/BootSourceTest.java
@@ -33,8 +33,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.openstack4j.api.OSClient;
-import org.openstack4j.api.image.ImageService;
-import org.openstack4j.model.image.Image;
+import org.openstack4j.api.image.v2.ImageService;
+import org.openstack4j.model.image.v2.Image;
 import org.openstack4j.model.storage.block.Volume;
 import org.openstack4j.model.storage.block.VolumeSnapshot;
 
@@ -114,8 +114,8 @@ public class BootSourceTest {
 
         OSClient<?> osClient = mock(OSClient.class);
         ImageService imageService = mock(ImageService.class);
-        when(osClient.images()).thenReturn(imageService);
-        doReturn(Collections.singletonList(image)).when(imageService).listAll();
+        when(osClient.imagesV2()).thenReturn(imageService);
+        doReturn(Collections.singletonList(image)).when(imageService).list();
 
         j.fakeOpenstackFactory(new Openstack(osClient));
         final String credentialId = j.dummyCredential();
@@ -128,7 +128,7 @@ public class BootSourceTest {
         assertEquals("image-id", item.name);
         assertEquals("image-id", item.value);
 
-        verify(imageService).listAll();
+        verify(imageService).list();
         verifyNoMoreInteractions(imageService);
     }
 


### PR DESCRIPTION
This PR aims to add glance v2 support that is already
implemented in openstack4j, fixing #77 . There is no reason to keep
support for glance V1 since OpenStack has been supporting
glanve V2 api for about 3 or 4 years and now V1 api is excluded
in stable releases like Rocky.

Also, **pom.xml** is pointing to openstack4j **3.1.1-SNAPSHOT** in order 
to fix the [parsing error](https://github.com/ContainX/openstack4j/commit/bb78146aa914b855c2d77e2b4d42e455190fb8eb). 

In order to this PR work properly, we need a new release of opentack4j. An[ issue](https://github.com/ContainX/openstack4j/issues/1213) was already opened requesting it. 