### PR TITLE
Adding IP address to node description

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlave.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlave.java
@@ -82,7 +82,7 @@ public class JCloudsSlave extends AbstractCloudSlave implements TrackedItem {
     ) throws IOException, Descriptor.FormException {
         super(
                 metadata.getName(),
-                null,
+                "IP: " + Openstack.getPublicAddress(metadata),
                 slaveOptions.getFsRoot(),
                 slaveOptions.getNumExecutors(),
                 Mode.NORMAL,


### PR DESCRIPTION
This change will make it easier to troubleshoot problems on VMs. (accessing a VM, but still...) 
The value is being used to set `OPENSTACK_PUBLIC_IP` environment variable, even when IP is not really public (without floating IP), so I think this won't be a problem here. :wink: 
Currently, to get IP address you have to either search for `OPENSTACK_PUBLIC_IP` in env or identify VM by slave's name on openstack.