### PR TITLE
Fix #77: Load all images from glance 2

### DIFF
--- a/src/test/java/jenkins/plugins/openstack/compute/internal/OpenstackTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/internal/OpenstackTest.java
@@ -72,7 +72,7 @@ public class OpenstackTest {
         final List images = Arrays.asList(mockImageNamedBar1, mockImageWithNullName, mockImageNamedBar2,
                 mockImageNamedFoo, mockImageNamedBar3);
         final OSClient mockClient = mock(OSClient.class, RETURNS_DEEP_STUBS);
-        when(mockClient.imagesV2().list()).thenReturn(images);
+        when(mockClient.imagesV2().list(any())).thenReturn(images);
         final Collection<Image> images0 = new ArrayList<>(
                 Arrays.asList(mockImageNamedBar2, mockImageNamedBar3, mockImageNamedBar1));
         final Collection<Image> images1 = new ArrayList<>(Arrays.asList(mockImageNamedFoo));

--- a/src/test/java/jenkins/plugins/openstack/compute/slaveopts/BootSourceTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/slaveopts/BootSourceTest.java
@@ -45,6 +45,8 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyMap;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -115,11 +117,10 @@ public class BootSourceTest {
         OSClient<?> osClient = mock(OSClient.class);
         ImageService imageService = mock(ImageService.class);
         when(osClient.imagesV2()).thenReturn(imageService);
-        doReturn(Collections.singletonList(image)).when(imageService).list();
+        doReturn(Collections.singletonList(image)).when(imageService).list(any());
 
         j.fakeOpenstackFactory(new Openstack(osClient));
         final String credentialId = j.dummyCredential();
-
 
         ListBoxModel list = id.doFillNameItems("", "OSurl", false, credentialId, "OSzone");
         assertThat(list.get(0).name, list, Matchers.<ListBoxModel.Option>iterableWithSize(2));
@@ -128,7 +129,7 @@ public class BootSourceTest {
         assertEquals("image-id", item.name);
         assertEquals("image-id", item.value);
 
-        verify(imageService).list();
+        verify(imageService).list(any());
         verifyNoMoreInteractions(imageService);
     }
 


### PR DESCRIPTION
The openstack4j does not implement pagination for glance 2 so it needs to be done explicitly.