### PR TITLE
Prevent provisioning failure when VolumeSnapshot has no description.

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
@@ -421,9 +421,9 @@ public class Openstack {
      *
      * @param volumeSnapshotId
      *            The ID of the volume snapshot whose description is to be retrieved.
-     * @return The description string.
+     * @return The description string, or null if there isn't one.
      */
-    public String getVolumeSnapshotDescription(String volumeSnapshotId) {
+    public @CheckForNull String getVolumeSnapshotDescription(String volumeSnapshotId) {
         return clientProvider.get().blockStorage().snapshots().get(volumeSnapshotId).getDescription();
     }
 

--- a/src/main/java/jenkins/plugins/openstack/compute/slaveopts/BootSource.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/slaveopts/BootSource.java
@@ -378,7 +378,7 @@ public abstract class BootSource extends AbstractDescribableImpl<BootSource> imp
             super.setServerBootSource(builder, os);
             final List<String> matchingIds = getDescriptor().findMatchingIds(os, name);
             final String id = selectIdFromListAndLogProblems(matchingIds, name, "VolumeSnapshots");
-            final String volumeSnapshotDescription = os.getVolumeSnapshotDescription(id);
+            final String volumeSnapshotDescriptionOrNull = os.getVolumeSnapshotDescription(id);
             final BlockDeviceMappingBuilder volumeBuilder = Builders.blockDeviceMapping()
                     .sourceType(BDMSourceType.SNAPSHOT)
                     .destinationType(BDMDestType.VOLUME)
@@ -387,7 +387,9 @@ public abstract class BootSource extends AbstractDescribableImpl<BootSource> imp
                     .bootIndex(0);
             builder.blockDevice(volumeBuilder.build());
             builder.addMetadataItem(OPENSTACK_BOOTSOURCE_VOLUMESNAPSHOT_ID_KEY, id);
-            builder.addMetadataItem(OPENSTACK_BOOTSOURCE_VOLUMESNAPSHOT_DESC_KEY, volumeSnapshotDescription);
+            if (volumeSnapshotDescriptionOrNull != null && !volumeSnapshotDescriptionOrNull.isEmpty()) {
+                builder.addMetadataItem(OPENSTACK_BOOTSOURCE_VOLUMESNAPSHOT_DESC_KEY, volumeSnapshotDescriptionOrNull);
+            }
         }
 
         @Override


### PR DESCRIPTION
https://github.com/jenkinsci/openstack-cloud-plugin/issues/220 reported `ClientResponseException{message=Invalid input for field/attribute jenkins-boot-volumesnapshot-description. Value: None. None is not of type 'string', status=400, status-code=BAD_REQUEST}` when the VolumeSnapshot has no description.
This code change now checks for null/empty and doesn't set the metadata in such situations.