### PR TITLE
Mark a node used only after a task has completed

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsComputer.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsComputer.java
@@ -123,12 +123,6 @@ public class JCloudsComputer extends AbstractCloudComputer<JCloudsSlave> impleme
         return super.isAcceptingTasks();
     }
 
-    @Override
-    public void taskAccepted(Executor executor, Queue.Task task) {
-        super.taskAccepted(executor, task);
-        used = true;
-    }
-
     /**
      * Has this computer been used to run builds?
      */
@@ -149,6 +143,7 @@ public class JCloudsComputer extends AbstractCloudComputer<JCloudsSlave> impleme
     }
 
     private void checkSlaveAfterTaskCompletion() {
+        used = true;
         // If the retention time for this computer is zero, this means it
         // should not be re-used: mark the node as "pending delete".
         if (getRetentionTime() == 0) {

--- a/src/test/java/jenkins/plugins/openstack/compute/JCloudsComputerTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/JCloudsComputerTest.java
@@ -1,5 +1,6 @@
 package jenkins.plugins.openstack.compute;
 
+import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import jenkins.plugins.openstack.PluginTestRule;
 import org.junit.Rule;
@@ -49,7 +50,9 @@ public class JCloudsComputerTest {
         computer.waitUntilOnline();
         FreeStyleProject p = j.createFreeStyleProject();
         p.setAssignedNode(slave);
-        p.scheduleBuild2(0).waitForStart();
+        FreeStyleBuild build = p.scheduleBuild2(0).waitForStart();
+        j.waitForCompletion(build);
+        j.waitUntilNoActivity();
         assertFalse(computer.isAcceptingTasks());
     }
 
@@ -64,7 +67,9 @@ public class JCloudsComputerTest {
         computer.waitUntilOnline();
         FreeStyleProject p = j.createFreeStyleProject();
         p.setAssignedNode(slave);
-        p.scheduleBuild2(0).waitForStart();
+        FreeStyleBuild build = p.scheduleBuild2(0).waitForStart();
+        j.waitForCompletion(build);
+        j.waitUntilNoActivity();
         assertTrue(computer.isAcceptingTasks());
     }
 }

--- a/src/test/java/jenkins/plugins/openstack/compute/JCloudsRetentionStrategyTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/JCloudsRetentionStrategyTest.java
@@ -158,6 +158,7 @@ public class JCloudsRetentionStrategyTest {
         p.setAssignedNode(slave);
         FreeStyleBuild build = p.scheduleBuild2(0).waitForStart();
         j.waitForCompletion(build);
+        j.waitUntilNoActivity();
 
         computer.getRetentionStrategy().check(computer);
 


### PR DESCRIPTION
This change addresses two problems with the "retention time=0"
use-case:
- If a node has multiple executors (and retention time is
  set to zero), we still want the node to accept tasks until
  one task finishes.
- Without this change, a node with retention time set to zero
  executing its first task will be marked as 'suspended' in the
  UI. In addition to being very confusing, it also means that if
  the node gets accidentally disconnected, reconnection won't be
  attempted.