### PR TITLE
Include credentials password in its cache fingerprint

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
@@ -45,6 +45,7 @@ import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 
+import com.cloudbees.plugins.credentials.common.PasswordCredentials;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.common.cache.Cache;
@@ -798,7 +799,11 @@ public class Openstack {
         public static @Nonnull Openstack get(
                 @Nonnull final String endPointUrl, final boolean ignoreSsl, @Nonnull final OpenstackCredential auth, @CheckForNull final String region
         ) throws FormValidation {
-            final String fingerprint = Util.getDigestOf(endPointUrl +  '\n' + ignoreSsl + '\n' + auth.toString() + '\n' + region);
+            final String fingerprint = Util.getDigestOf(endPointUrl +  '\n'
+                    + ignoreSsl + '\n'
+                    + auth.toString() + '\n'
+                    + (auth instanceof PasswordCredentials ? ((PasswordCredentials) auth).getPassword().getEncryptedValue() + '\n' : "")
+                    + region);
             final FactoryEP ep = ExtensionList.lookup(FactoryEP.class).get(0);
             final Callable<Openstack> cacheMissFunction = new Callable<Openstack>() {
                 @Override


### PR DESCRIPTION
At present, the plugin continues to use the old Openstack session after the user has updated the credentials with a new password.  This caching can confuse people as the password being used isn't necessarily the current password from the credentials :grin:
Updating the credentials password should result in a new Openstack instance being created with that new password immediately (without having to wait 10 minutes for the cache to expire).

- Added unit test `JCloudsCloudTest.cachedOpenstackInstanceInvalidatedIfPasswordChanges()` to demonstrate the problem.
- Added suggested fix to `Openstack.FactoryEP.get(...)`