### PR TITLE
Evaluate instance capacity based on Jenkins computers too

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloud-stats</artifactId>
-            <version>0.14</version>
+            <version>0.21</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsCloud.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsCloud.java
@@ -17,8 +17,10 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import javax.servlet.http.HttpServletResponse;
 
@@ -33,6 +35,7 @@ import jenkins.plugins.openstack.compute.auth.*;
 import jenkins.plugins.openstack.compute.slaveopts.LauncherFactory;
 import jenkins.util.Timer;
 import org.acegisecurity.Authentication;
+import org.jenkinsci.plugins.cloudstats.ActivityIndex;
 import org.jenkinsci.plugins.cloudstats.CloudStatistics;
 import org.jenkinsci.plugins.cloudstats.ProvisioningActivity;
 import org.jenkinsci.plugins.cloudstats.TrackedPlannedNode;
@@ -212,55 +215,48 @@ public class JCloudsCloud extends Cloud implements SlaveOptions.Holder {
      * The queue contains the same template in as many instances as is the number of machines that can be safely
      * provisioned without violating instanceCap constrain.
      */
-    private @Nonnull Queue<JCloudsSlaveTemplate> getAvailableTemplateProvider(@CheckForNull Label label) {
-        final String labelString = (label != null) ? label.toString() : "none";
-        final List<Server> runningNodes = getOpenstack().getRunningNodes();
+    private @Nonnull Queue<JCloudsSlaveTemplate> getAvailableTemplateProvider(@CheckForNull Label label, int excessWorkload) {
         final int globalMax = getEffectiveSlaveOptions().getInstanceCap();
 
         final Queue<JCloudsSlaveTemplate> queue = new ConcurrentLinkedDeque<>();
-        int globalCapacity = globalMax - runningNodes.size();
-        if (globalCapacity <= 0) {
-            LOGGER.log(Level.INFO,
-                    "Global instance cap ({0}) reached while adding capacity for label: {1}",
-                    new Object[] { globalMax, labelString}
-            );
-            return queue; // No need to proceed any further;
+
+        List<JCloudsComputer> cloudComputers = JCloudsComputer.getAll().stream().filter(
+                it -> name.equals(it.getId().getCloudName())
+        ).collect(Collectors.toList());
+
+        int nodeCount = cloudComputers.size();
+        if (nodeCount >= globalMax) {
+            return queue; // more slaves then declared - no need to query openstack
         }
 
-        final Map<JCloudsSlaveTemplate, Integer> template2capacity = new LinkedHashMap<>();
+        final List<Server> runningNodes = getOpenstack().getRunningNodes();
+
+        int serverCount = runningNodes.size();
+        if (serverCount >= globalMax) {
+            return queue; // more servers than needed - no need to proceed any further
+        }
+
+        int globalCapacity = globalMax - Math.max(nodeCount, serverCount);
+        assert globalCapacity > 0;
+
         for (JCloudsSlaveTemplate t : templates) {
             if (t.canProvision(label)) {
-                final int templateMax = t.getEffectiveSlaveOptions().getInstanceCap();
+                SlaveOptions opts = t.getEffectiveSlaveOptions();
+                final int templateMax = opts.getInstanceCap();
+                long templateNodeCount = Math.max(
+                        cloudComputers.stream().filter(it -> t.name.equals(it.getId().getTemplateName())).count(),
+                        runningNodes.stream().filter(t::hasProvisioned).count()
+                );
+                if (templateNodeCount >= templateMax) continue; // Exceeded
 
-                int templateCapacity = templateMax;
-                for (Server server : runningNodes) {
-                    if (t.hasProvisioned(server)) {
-                        templateCapacity--;
-                    }
-                }
+                long templateCapacity = templateMax - templateNodeCount;
+                assert templateCapacity > 0;
 
-                if (templateCapacity > 0) {
-                    template2capacity.put(t, templateCapacity);
-                } else {
-                    LOGGER.log(Level.INFO,
-                            "Template instance cap for {0} ({1}) reached while adding capacity for label: {2}",
-                            new Object[] { t.name, templateMax, labelString }
-                    );
-                }
-            }
-        }
+                for (int i = 0; i < templateCapacity; i++) {
+                    int size = queue.size();
+                    if (size >= globalCapacity || size >= excessWorkload) return queue;
 
-        done: for (Map.Entry<JCloudsSlaveTemplate, Integer> e : template2capacity.entrySet()) {
-            for (int i = e.getValue(); i > 0; i--) {
-                if (globalCapacity > 0) {
-                    queue.add(e.getKey());
-                    globalCapacity--;
-                } else {
-                    LOGGER.log(Level.INFO,
-                            "Global instance cap ({0}) reached while adding capacity for label: {1}",
-                            new Object[] { globalMax, labelString}
-                    );
-                    break done;
+                    queue.add(t);
                 }
             }
         }
@@ -270,14 +266,14 @@ public class JCloudsCloud extends Cloud implements SlaveOptions.Holder {
 
     @Override
     public Collection<NodeProvisioner.PlannedNode> provision(Label label, int excessWorkload) {
-        Queue<JCloudsSlaveTemplate> templateProvider = getAvailableTemplateProvider(label);
+        Queue<JCloudsSlaveTemplate> templateProvider = getAvailableTemplateProvider(label, excessWorkload);
 
         List<PlannedNode> plannedNodeList = new ArrayList<>();
         while (excessWorkload > 0 && !Jenkins.getActiveInstance().isQuietingDown() && !Jenkins.getActiveInstance().isTerminating()) {
 
             final JCloudsSlaveTemplate template = templateProvider.poll();
             if (template == null) {
-                LOGGER.info("Instance cap exceeded on all available templates");
+                LOGGER.info("Instance cap exceeded for cloud " + name + " while provisioning for label " + label);
                 break;
             }
 

--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
@@ -399,8 +399,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
     /*package for testing*/ List<? extends Server> getRunningNodes() {
         List<Server> tmplt = new ArrayList<>();
         for (Server server : cloud.getOpenstack().getRunningNodes()) {
-            Map<String, String> md = server.getMetadata();
-            if (name.equals(md.get(OPENSTACK_TEMPLATE_NAME_KEY))) {
+            if (hasProvisioned(server)) {
                 tmplt.add(server);
             }
         }

--- a/src/test/java/jenkins/plugins/openstack/compute/InstanceCapacityTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/InstanceCapacityTest.java
@@ -1,0 +1,169 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.plugins.openstack.compute;
+
+import hudson.model.Descriptor;
+import hudson.model.Label;
+import hudson.model.labels.LabelAtom;
+import hudson.slaves.NodeProvisioner;
+import jenkins.plugins.openstack.PluginTestRule;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
+import org.jenkinsci.plugins.cloudstats.CloudStatistics;
+import org.jenkinsci.plugins.cloudstats.ProvisioningActivity;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.LoggerRule;
+import org.openstack4j.model.compute.Server;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Set;
+import java.util.logging.Level;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class InstanceCapacityTest {
+
+    @Rule
+    public PluginTestRule j = new PluginTestRule();
+
+    @Rule
+    public LoggerRule lr = new LoggerRule();
+
+    @Test
+    public void useSeveralTemplatesToProvisionInOneBatchWhenTemplateInstanceCapExceeded() throws Exception {
+        SlaveOptions opts = j.defaultSlaveOptions().getBuilder().instanceCap(1).build();
+        JCloudsCloud cloud = j.configureSlaveLaunchingWithFloatingIP(j.dummyCloud(
+                j.dummySlaveTemplate(opts, "label 1"),
+                j.dummySlaveTemplate(opts, "label 2"),
+                j.dummySlaveTemplate(opts, "label 3")
+        ));
+
+        Collection<NodeProvisioner.PlannedNode> plan = cloud.provision(Label.get("label"), 4);
+        assertEquals(3, plan.size());
+
+        int cntr = 1;
+        for (NodeProvisioner.PlannedNode pn: plan) {
+            LabelAtom expectedLabel = LabelAtom.get(String.valueOf(cntr));
+
+            Set<LabelAtom> assignedLabels = pn.future.get().getAssignedLabels();
+            assertTrue(assignedLabels.toString(), assignedLabels.contains(expectedLabel));
+            cntr++;
+        }
+    }
+
+    @Test
+    public void reportInstanceCapBasedOnSlaves() throws IOException, Descriptor.FormException {
+        SlaveOptions init = j.defaultSlaveOptions();
+        JCloudsSlaveTemplate restrictedTmplt = j.dummySlaveTemplate(init.getBuilder().instanceCap(1).build(), "restricted common");
+        JCloudsSlaveTemplate openTmplt = j.dummySlaveTemplate(init.getBuilder().instanceCap(null).build(), "open common");
+        JCloudsCloud cloud = j.dummyCloud(init.getBuilder().instanceCap(2).build(), restrictedTmplt, openTmplt);
+        j.configureSlaveLaunchingWithFloatingIP(cloud);
+
+        Server server = j.mockServer().name("foo0").withFixedIPv4("0.0.0.0").get();
+        ProvisioningActivity.Id id = new ProvisioningActivity.Id(cloud.name, restrictedTmplt.name);
+        j.jenkins.addNode(new JCloudsSlave(id, server, "restricted common", restrictedTmplt.getEffectiveSlaveOptions()));
+
+        lr.capture(5);
+        lr.record(JCloudsCloud.class, Level.INFO);
+
+        assertEquals(0, cloud.provision(Label.get("restricted"), 1).size());
+        assertThat(lr.getMessages(), hasItem("Instance cap exceeded for cloud openstack while provisioning for label restricted"));
+        assertThat(lr.getMessages(), hasSize(1));
+
+        lr.getMessages().clear();
+        assertEquals(1, cloud.provision(Label.get("open||open"), 3).size());
+        assertThat(lr.getMessages(), hasItem("Instance cap exceeded for cloud openstack while provisioning for label open||open"));
+        assertThat(lr.getMessages(), hasSize(1));
+    }
+
+    @Test
+    public void doNotProvisionOnceInstanceCapReached() throws Exception {
+        SlaveOptions init = j.defaultSlaveOptions();
+        JCloudsSlaveTemplate restrictedTmplt = j.dummySlaveTemplate(init.getBuilder().instanceCap(1).build(), "restricted common");
+        JCloudsSlaveTemplate openTmplt = j.dummySlaveTemplate(init.getBuilder().instanceCap(null).build(), "open common");
+        JCloudsCloud cloud = j.dummyCloud(init.getBuilder().instanceCap(4).build(), restrictedTmplt, openTmplt);
+        j.configureSlaveLaunchingWithFloatingIP(cloud);
+
+        Label restricted = Label.get("restricted");
+        Label open = Label.get("open");
+
+        // Template quota exceeded
+        assertProvisioned(1, cloud.provision(restricted, 2));
+        assertEquals(1, runningServersCount(cloud));
+        assertEquals(1, runningServersCount(restrictedTmplt));
+
+        assertProvisioned(0, cloud.provision(restricted, 1));
+        assertEquals(1, runningServersCount(cloud));
+        assertEquals(1, runningServersCount(restrictedTmplt));
+
+        // Cloud quota exceeded
+        assertProvisioned(2, cloud.provision(open, 2));
+        assertEquals(3, runningServersCount(cloud));
+        assertEquals(2, runningServersCount(openTmplt));
+
+        assertProvisioned(1, cloud.provision(open, 2));
+        assertEquals(4, runningServersCount(cloud));
+        assertEquals(3, runningServersCount(openTmplt));
+
+        // Both exceeded
+        assertProvisioned(0, cloud.provision(restricted, 1));
+        assertProvisioned(0, cloud.provision(open, 1));
+        assertEquals(4, runningServersCount(cloud));
+        assertEquals(1, runningServersCount(restrictedTmplt));
+        assertEquals(3, runningServersCount(openTmplt));
+
+        // When one node gets deleted
+        Server server = openTmplt.getRunningNodes().get(0);
+        cloud.getOpenstack().destroyServer(server);
+        j.jenkins.removeNode(j.jenkins.getNode(server.getName()));
+        assertEquals(3, runningServersCount(cloud));
+
+        // Choose the available one when multiple options
+        assertProvisioned(1, cloud.provision(Label.get("common"), 1));
+        assertEquals(4, runningServersCount(cloud));
+        assertEquals(1, runningServersCount(restrictedTmplt));
+        assertEquals(3, runningServersCount(openTmplt));
+    }
+
+    public int runningServersCount(JCloudsSlaveTemplate restrictedTmplt) {
+        return restrictedTmplt.getRunningNodes().size();
+    }
+
+    public int runningServersCount(JCloudsCloud cloud) {
+        return cloud.getOpenstack().getRunningNodes().size();
+    }
+
+    private void assertProvisioned(int expectedCount, Collection<NodeProvisioner.PlannedNode> nodes) throws Exception {
+        assertEquals(expectedCount, nodes.size());
+        for (NodeProvisioner.PlannedNode node : nodes) {
+            node.future.get();
+        }
+    }
+}


### PR DESCRIPTION
- The exceeded capacity logs ware illogical and often repeated.
- Consul the number of Jenkins computers to save some OS calls
  - There also ware an incident when computer count was severely larger than declared but since servers ware not booted, instance cap did not kicked in.
- Avoid computing more options than needed.