### PR TITLE
Fix #246: Drop existing disposables in case of cloud removal

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsCloud.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsCloud.java
@@ -104,6 +104,9 @@ public class JCloudsCloud extends Cloud implements SlaveOptions.Holder {
         return clouds;
     }
 
+    /**
+     * @throws IllegalArgumentException If the OpenStack cloud with given name does not exist.
+     */
     public static @Nonnull JCloudsCloud getByName(@Nonnull String name) throws IllegalArgumentException {
         Cloud cloud = Jenkins.get().clouds.getByName(name);
         if (cloud instanceof JCloudsCloud) return (JCloudsCloud) cloud;

--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlave.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlave.java
@@ -368,6 +368,11 @@ public class JCloudsSlave extends AbstractCloudSlave implements TrackedItem {
         return JCloudsCloud.getByName(cloudName).getOpenstack();
     }
 
+    /**
+     * Second layer disposable to track removal of Jenkins slave.
+     *
+     * @see DestroyMachine
+     */
     private final static class RecordDisposal implements Disposable {
         private static final long serialVersionUID = -3623764445481732365L;
 
@@ -392,6 +397,10 @@ public class JCloudsSlave extends AbstractCloudSlave implements TrackedItem {
                     );
                     statistics.attach(activity, ProvisioningActivity.Phase.COMPLETED, attachment);
                 }
+
+                // Log the problem once and then stop tracking it
+                if (ex instanceof DestroyMachine.CloudGoneException) return State.PURGED;
+
                 throw ex;
             }
         }


### PR DESCRIPTION
Fixing https://github.com/jenkinsci/openstack-cloud-plugin/issues/246

The problem should be logged exactly once before the plugin stops tracking the resource.