### PR TITLE
Do not remove computer before it is used

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsComputer.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsComputer.java
@@ -123,12 +123,6 @@ public class JCloudsComputer extends AbstractCloudComputer<JCloudsSlave> impleme
         return super.isAcceptingTasks();
     }
 
-    @Override
-    public void taskAccepted(Executor executor, Queue.Task task) {
-        super.taskAccepted(executor, task);
-        used = true;
-    }
-
     /**
      * Has this computer been used to run builds?
      */
@@ -149,6 +143,7 @@ public class JCloudsComputer extends AbstractCloudComputer<JCloudsSlave> impleme
     }
 
     private void checkSlaveAfterTaskCompletion() {
+        used = true;
         // If the retention time for this computer is zero, this means it
         // should not be re-used: mark the node as "pending delete".
         if (getRetentionTime() == 0) {

--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsPreCreationThread.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsPreCreationThread.java
@@ -1,9 +1,11 @@
 package jenkins.plugins.openstack.compute;
 
 import java.lang.Math;
+import java.util.Queue;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -97,6 +99,11 @@ public final class JCloudsPreCreationThread extends AsyncPeriodicWork {
                         }
                         if (retentionTime == 0 && !computer.isUsed() && (template.getActiveNodesTotal(true) - 1) < instancesMin) {
                             return true;
+                        }
+                    } else {
+                        if(computer !=null && retentionTime == 0) {
+                            //check if there is a task in the queue - retentionTime=0 && instancesMin<0 can cause removal of computer before it was ever used.
+                            return !Jenkins.getInstanceOrNull().getQueue().getBuildableItems(computer).isEmpty();
                         }
                     }
                 }

--- a/src/test/java/jenkins/plugins/openstack/compute/JCloudsComputerTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/JCloudsComputerTest.java
@@ -1,5 +1,6 @@
 package jenkins.plugins.openstack.compute;
 
+import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import jenkins.plugins.openstack.PluginTestRule;
 import org.junit.Rule;
@@ -49,7 +50,9 @@ public class JCloudsComputerTest {
         computer.waitUntilOnline();
         FreeStyleProject p = j.createFreeStyleProject();
         p.setAssignedNode(slave);
-        p.scheduleBuild2(0).waitForStart();
+        FreeStyleBuild build = p.scheduleBuild2(0).waitForStart();
+        j.waitForCompletion(build);
+        j.waitUntilNoActivity();
         assertFalse(computer.isAcceptingTasks());
     }
 
@@ -64,7 +67,9 @@ public class JCloudsComputerTest {
         computer.waitUntilOnline();
         FreeStyleProject p = j.createFreeStyleProject();
         p.setAssignedNode(slave);
-        p.scheduleBuild2(0).waitForStart();
+        FreeStyleBuild build = p.scheduleBuild2(0).waitForStart();
+        j.waitForCompletion(build);
+        j.waitUntilNoActivity();
         assertTrue(computer.isAcceptingTasks());
     }
 }

--- a/src/test/java/jenkins/plugins/openstack/compute/JCloudsRetentionStrategyTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/JCloudsRetentionStrategyTest.java
@@ -158,6 +158,7 @@ public class JCloudsRetentionStrategyTest {
         p.setAssignedNode(slave);
         FreeStyleBuild build = p.scheduleBuild2(0).waitForStart();
         j.waitForCompletion(build);
+        j.waitUntilNoActivity();
 
         computer.getRetentionStrategy().check(computer);
 


### PR DESCRIPTION
A computer can be removed shortly after provision (despite it was not used and there is still task for it) if retention time = 0 and instancesMin = 0.
Let such computer stay in Jenkins if there is a task for it in the queue.