### PR TITLE
Check only channel.

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsLauncher.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsLauncher.java
@@ -39,7 +39,7 @@ public class JCloudsLauncher extends DelegatingComputerLauncher {
         long timeout = node.getCreatedTime() + configuredTimeout;
         do {
             launcher(computer).launch(computer, listener);
-            if (computer.isOnline()) return;
+            if (computer.getChannel() != null) return;
 
             listener.getLogger().println("Launcher failed to bring the node online. Retrying ...");
 


### PR DESCRIPTION
Check rather the channel then online state - agent can go offline during connection (whether it is due to user request or system action). 