### PR TITLE
Do not count connection time into iddle time.

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsComputer.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsComputer.java
@@ -41,7 +41,7 @@ public class JCloudsComputer extends AbstractCloudComputer<JCloudsSlave> impleme
     private static final Logger LOGGER = Logger.getLogger(JCloudsComputer.class.getName());
     private final ProvisioningActivity.Id provisioningId;
     private volatile AtomicInteger used = new AtomicInteger(0);
-    private transient long connectionTime;
+    private transient long connectedTime;
 
     /**
      * Get all Openstack computers.
@@ -200,11 +200,19 @@ public class JCloudsComputer extends AbstractCloudComputer<JCloudsSlave> impleme
 
     public void setChannel(Channel channel, OutputStream launchLog, Channel.Listener listener) throws IOException, InterruptedException {
         super.setChannel(channel, launchLog, listener);
-        connectionTime = System.currentTimeMillis();
+        connectedTime = System.currentTimeMillis();
     }
 
-    public long getConnectionTime(){
-        return connectionTime;
+    public long getConnectedTime(){
+        return connectedTime;
+    }
+
+    public long getIdleSince(){
+        long iddleTime = super.getIdleStartMilliseconds();
+        if(connectedTime > iddleTime) {
+            return connectedTime;
+        }
+        return iddleTime;
     }
 
 

--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsComputer.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsComputer.java
@@ -4,6 +4,7 @@ import hudson.model.Computer;
 import hudson.model.Executor;
 import hudson.model.Queue;
 import hudson.node_monitors.DiskSpaceMonitorDescriptor;
+import hudson.remoting.Channel;
 import hudson.security.Permission;
 import hudson.slaves.AbstractCloudComputer;
 import hudson.slaves.OfflineCause;
@@ -26,6 +27,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -39,6 +41,7 @@ public class JCloudsComputer extends AbstractCloudComputer<JCloudsSlave> impleme
     private static final Logger LOGGER = Logger.getLogger(JCloudsComputer.class.getName());
     private final ProvisioningActivity.Id provisioningId;
     private volatile AtomicInteger used = new AtomicInteger(0);
+    private transient long connectionTime;
 
     /**
      * Get all Openstack computers.
@@ -193,6 +196,17 @@ public class JCloudsComputer extends AbstractCloudComputer<JCloudsSlave> impleme
             throw ex;
         }
     }
+
+
+    public void setChannel(Channel channel, OutputStream launchLog, Channel.Listener listener) throws IOException, InterruptedException {
+        super.setChannel(channel, launchLog, listener);
+        connectionTime = System.currentTimeMillis();
+    }
+
+    public long getConnectionTime(){
+        return connectionTime;
+    }
+
 
     private static final class PendingTermination extends SimpleOfflineCause {
 

--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsRetentionStrategy.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsRetentionStrategy.java
@@ -57,17 +57,8 @@ public class JCloudsRetentionStrategy extends RetentionStrategy<JCloudsComputer>
 
         final int retentionTime = node.getSlaveOptions().getRetentionTime();
         if (retentionTime <= 0) return; // 0 is handled in JCloudsComputer, negative values needs no handling
-
-        long idleSince = c.getIdleStartMilliseconds();
-        final long connectionTime = c.getConnectionTime();
-        if(connectionTime == 0 ) {
-            //channel is already set, but connection activity is not finished completely
-            return;
-        }
-        if(connectionTime > idleSince) {
-            //idle should be counted without time consumed by establishing of connection
-            idleSince = connectionTime;
-        }
+        if(c.getConnectedTime() == 0) return; //channel is set but connection process is not fully finished.
+        final long idleSince = c.getIdleSince();
         final long idleMilliseconds = System.currentTimeMillis() - idleSince;
         if (idleMilliseconds > TimeUnit.MINUTES.toMillis(retentionTime)) {
             if (JCloudsPreCreationThread.isNeededReadyComputer(node.getComputer())) {

--- a/src/test/java/jenkins/plugins/openstack/compute/JCloudsRetentionStrategyTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/JCloudsRetentionStrategyTest.java
@@ -164,6 +164,24 @@ public class JCloudsRetentionStrategyTest {
         }
     }
 
+    @Test
+    public void doNotRemoveSlaveShortlyAfterConnection() throws Exception {
+        LauncherFactory launcherFactory = new TestCommandLauncherFactory("bash -c \"sleep 70 && java -jar '%s'\"");
+        JCloudsCloud cloud = j.configureSlaveProvisioningWithFloatingIP(j.dummyCloud(j.dummySlaveTemplate(
+                j.defaultSlaveOptions().getBuilder().retentionTime(1).launcherFactory(launcherFactory).build(),
+                "label"
+        )));
+
+        JCloudsSlave slave = j.provision(cloud, "label");
+        JCloudsComputer computer = (JCloudsComputer) slave.toComputer();
+        while(computer.getChannel() == null){
+            Thread.sleep(1000);
+        }
+        computer.getRetentionStrategy().check(computer);
+
+        assertFalse(computer.isPendingDelete());
+    }
+
     private JCloudsComputer waitForProvisionedComputer() throws InterruptedException {
         while (true) {
             List<JCloudsComputer> computers = JCloudsComputer.getAll();

--- a/src/test/java/jenkins/plugins/openstack/compute/JCloudsRetentionStrategyTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/JCloudsRetentionStrategyTest.java
@@ -166,6 +166,7 @@ public class JCloudsRetentionStrategyTest {
 
     @Test
     public void doNotRemoveSlaveShortlyAfterConnection() throws Exception {
+        Assume.assumeFalse(Functions.isWindows());
         LauncherFactory launcherFactory = new TestCommandLauncherFactory("bash -c \"sleep 70 && java -jar '%s'\"");
         JCloudsCloud cloud = j.configureSlaveProvisioningWithFloatingIP(j.dummyCloud(j.dummySlaveTemplate(
                 j.defaultSlaveOptions().getBuilder().retentionTime(1).launcherFactory(launcherFactory).build(),


### PR DESCRIPTION
Idle time should not be longer then connection time. If the connection is establishing for a long time, it can cause returning machine without ever using it - immediately after connection. 