### PR TITLE
Adding a new feature to schedule slaves for termination

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,14 +7,14 @@
     </parent>
 
     <artifactId>openstack-cloud</artifactId>
-    <version>2.48-SNAPSHOT</version>
+    <version>2.47</version>
     <packaging>hpi</packaging>
     <name>OpenStack Cloud Plugin</name>
     <description>Allows Jenkins to build OpenStack Slaves</description>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Openstack+Cloud+Plugin</url>
 
     <properties>
-        <jenkins.version>2.98</jenkins.version>
+        <jenkins.version>2.176.1</jenkins.version>
         <jenkins-test-harness.version>2.27</jenkins-test-harness.version>
         <java.level>8</java.level>
         <concurrency>1C</concurrency>
@@ -30,9 +30,9 @@
 
     <developers>
         <developer>
-          <id>olivergondza</id>
-          <name>Oliver Gondža</name>
-          <email>ogondza@gmail.com</email>
+            <id>olivergondza</id>
+            <name>Oliver Gondža</name>
+            <email>ogondza@gmail.com</email>
         </developer>
     </developers>
 
@@ -100,12 +100,6 @@
             <artifactId>resource-disposer</artifactId>
             <version>0.5</version>
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.8</version>
-            <optional>true</optional>
-        </dependency>
 
         <!-- Hardcoding upper-bound versions of dependencies -->
         <dependency>
@@ -116,12 +110,12 @@
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>symbol-annotation</artifactId>
-            <version>1.5</version>
+            <version>1.18</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.36</version>
+            <version>1.58</version>
         </dependency>
         <dependency>
             <groupId>org.apache.ant</groupId>
@@ -139,17 +133,12 @@
             <version>2.4.2</version>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci</groupId>
-            <artifactId>symbol-annotation</artifactId>
-            <version>1.17</version>
-        </dependency>
-        <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
             <version>1.23</version>
         </dependency>
-
         <!-- Test Dependencies -->
+
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
@@ -160,31 +149,6 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.9.5</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-cps</artifactId>
-            <version>2.25</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-support</artifactId>
-            <classifier>tests</classifier>
-            <version>2.12</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-job</artifactId>
-            <version>2.9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-basic-steps</artifactId>
-            <version>2.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -213,8 +177,35 @@
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+            <version>2.20</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.18</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <version>2.31</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <version>2.70</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-support</artifactId>
+            <version>3.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
-
     <build>
         <pluginManagement>
             <plugins>
@@ -233,7 +224,7 @@
                         </additionalOptions>
                     </configuration>
                 </plugin>
-                </plugins>
+            </plugins>
         </pluginManagement>
         <finalName>${project.artifactId}</finalName>
     </build>
@@ -242,7 +233,7 @@
         <connection>scm:git:ssh://github.com/jenkinsci/openstack-cloud-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/openstack-cloud-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/openstack-cloud-plugin</url>
-        <tag>HEAD</tag>
+        <tag>openstack-cloud-2.47</tag>
     </scm>
 
     <repositories>
@@ -258,3 +249,4 @@
         </pluginRepository>
     </pluginRepositories>
 </project>
+

--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsPreCreationThread.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsPreCreationThread.java
@@ -2,10 +2,12 @@ package jenkins.plugins.openstack.compute;
 
 import java.lang.Math;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import hudson.model.Executor;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -13,6 +15,7 @@ import hudson.Extension;
 import hudson.Functions;
 import hudson.model.TaskListener;
 import hudson.model.AsyncPeriodicWork;
+import org.openstack4j.model.compute.Server;
 
 /**
  * Periodically ensure enough slaves are created.
@@ -93,6 +96,91 @@ public final class JCloudsPreCreationThread extends AsyncPeriodicWork {
     }
 
     /**
+     * Methods which return the list of VM
+     */
+    public static List<? extends Server> getVmList(String templateName, String cloudName){
+        List<? extends Server> vmList = null;
+        for (JCloudsCloud cloud : JCloudsCloud.getClouds()) {
+            if (cloud.getDisplayName().equals(cloudName)){
+                vmList = cloud.getTemplate(templateName).getRunningNodes();
+            }
+        }
+        return vmList;
+    }
+
+    /**
+     * Methods which return the name of the oldestVM for a specific template.
+     */
+    public static String getOldestVm(String templateName, String cloudName){
+        return getOldestVM(templateName, cloudName).getName();
+    }
+
+
+    /**
+     * Methods which return the oldestVM
+     * return a Server
+     * return a VM which is not offline/Pending delete in Jenkins
+     */
+    private static Server getOldestVM(String templateName, String cloudName){
+        Server oldestVm = null;
+        long oldestVmTime;
+        long currentVMTime;
+        String computerName;
+        String vmName;
+        List<? extends Server> vmList = getVmList(templateName, cloudName);
+        List<JCloudsComputer> listComputer = JCloudsComputer.getAll();
+        if (oldestVm == null){
+            oldestVm = vmList.get(0);
+        }
+        for (int i = 0; i<vmList.size(); i++){
+            oldestVmTime = oldestVm.getCreated().getTime();
+            currentVMTime = vmList.get(i).getCreated().getTime();
+            if (oldestVmTime > currentVMTime){
+                for (int y = 0; y<listComputer.size(); y++){
+                    computerName = listComputer.get(y).getName();
+                    vmName = vmList.get(i).getName();
+                    if (computerName.equals(vmName)){
+                        if (!listComputer.get(y).isOffline()){
+                            oldestVm = vmList.get(i);
+                        }
+                    }
+                }
+            }
+        }
+        return oldestVm;
+    }
+
+
+    /**
+     * Methods which return the number of free executors for a specific template
+     * take the template name in parameter.
+     */
+    public static int getNumOfFreeExec(String templateName) {
+        int nbFreeExecutors = 0;
+        //List of Jenkins computer (VM into Jenkins)
+        List<JCloudsComputer> listComputer = JCloudsComputer.getAll();
+        List<Executor> listExecutors;
+        //For each computer..
+        for (int y=0; y<listComputer.size(); y++) {
+            //If this Virtual machine was created with the Template in parameters
+            //and
+            //If this VM is connected
+            if ((listComputer.get(y).getId().getTemplateName().equals(templateName)) && (listComputer.get(y).isOnline())){
+                //We've get the VM executors into a List
+                listExecutors = listComputer.get(y).getExecutors();
+                //For each executors in the list
+                for (int i = 0; i<listExecutors.size(); i++) {
+                    //If the executor is free
+                    if (listExecutors.get(i).isIdle()){
+                        nbFreeExecutors = nbFreeExecutors + 1;
+                    }
+                }
+            }
+        }
+        return nbFreeExecutors;
+    }
+
+    /**
      * Should a slave be retained to meet the minimum instances constraint?
      *
      * @param computer Idle, not pending delete, not user offline but overdue w.r.t. retention time.
@@ -115,4 +203,33 @@ public final class JCloudsPreCreationThread extends AsyncPeriodicWork {
 
     @Override protected Level getNormalLoggingLevel() { return Level.FINE; }
     @Override protected Level getSlowLoggingLevel() { return Level.INFO; }
+
+    public static class OldestVM {
+
+        //attributes
+        public String templateName;
+        public String oldestVmName;
+
+        //Constructor
+        public OldestVM(String templateName, String oldestVmName){
+            this.templateName = templateName;
+            this.oldestVmName = oldestVmName;
+        }
+
+        public String getOldestVmName() {
+            return oldestVmName;
+        }
+
+        public String getTemplateName() {
+            return templateName;
+        }
+
+        public void setOldestVmName(String oldestVmName) {
+            this.oldestVmName = oldestVmName;
+        }
+
+        public void setTemplateName(String templateName) {
+            this.templateName = templateName;
+        }
+    }
 }

--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsRetentionStrategy.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsRetentionStrategy.java
@@ -9,7 +9,9 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
@@ -20,6 +22,7 @@ import java.util.logging.Logger;
  */
 public class JCloudsRetentionStrategy extends RetentionStrategy<JCloudsComputer> {
     private transient ReentrantLock checkLock;
+    private static List<JCloudsPreCreationThread.OldestVM> listOldestVm = new ArrayList<>();
 
     @DataBoundConstructor
     public JCloudsRetentionStrategy() {
@@ -48,33 +51,108 @@ public class JCloudsRetentionStrategy extends RetentionStrategy<JCloudsComputer>
     }
 
     private void doCheck(JCloudsComputer c) {
-        if (c.isPendingDelete()) return; // No need to do it again
+        if (c.isPendingDelete()) return;
         if (c.isConnecting()) return; // Do not discard slave while launching for the first time when "idle time" does not make much sense
-        if (!c.isIdle() || c.getOfflineCause() instanceof OfflineCause.UserCause) return; // Occupied by user initiated activity
-
         final JCloudsSlave node = c.getNode();
-        if (node == null) return; // Node is gone already
+        boolean oldestSlaveTermination = node.getSlaveOptions().getOldestSlaveTermination();
+        String templateName = c.getId().getTemplateName();
+        String cloudName = c.getId().getCloudName();
+        String oldestVmName = "";
 
-        final int retentionTime = node.getSlaveOptions().getRetentionTime();
-        if (retentionTime <= 0) return; // 0 is handled in JCloudsComputer, negative values needs no handling
-        final long idleSince = c.getIdleStart();
-        final long idleMilliseconds = getNow() - idleSince;
-        if (idleMilliseconds > TimeUnit.MINUTES.toMillis(retentionTime)) {
-            if (JCloudsPreCreationThread.isNeededReadyComputer(node.getComputer())) {
-                LOGGER.info("Keeping " + c .getName() + " to meet minimum requirements");
-                return;
-            }
-            LOGGER.info("Scheduling " + c .getName() + " for termination after " +  retentionTime+ " minutes as it was idle since " + new Date(idleSince));
-            if (LOGGER.isLoggable(Level.FINE)) {
-                try {
-                    ByteArrayOutputStream out = new ByteArrayOutputStream();
-                    Jenkins.XSTREAM2.toXMLUTF8(node, out);
-                    LOGGER.fine(out.toString("UTF-8"));
-                } catch (IOException e) {
-                    LOGGER.log(Level.WARNING, "Failed to dump node config", e);
+        //case where the checkbox isn't checked
+        if (oldestSlaveTermination == false) {
+            if (!c.isIdle() || c.getOfflineCause() instanceof OfflineCause.UserCause)
+                return; // Occupied by user initiated activity
+
+            if (node == null) return; // Node is gone already
+
+            final int retentionTime = node.getSlaveOptions().getRetentionTime();
+
+            if ((retentionTime >= 0)) {// 0 is handled in JCloudsComputer, negative values needs no handling
+                final long idleSince = c.getIdleStart();
+                final long idleMilliseconds = getNow() - idleSince;
+                if (idleMilliseconds > TimeUnit.MINUTES.toMillis(retentionTime)) {
+                    if (JCloudsPreCreationThread.isNeededReadyComputer(node.getComputer())) {
+                        LOGGER.info("Keeping " + c.getName() + " to meet minimum requirements");
+                        return;
+                    }
+                    LOGGER.info("Scheduling " + c.getName() + " for termination after " + retentionTime + " minutes as it was idle since " + new Date(idleSince));
+                    if (LOGGER.isLoggable(Level.FINE)) {
+                        try {
+                            ByteArrayOutputStream out = new ByteArrayOutputStream();
+                            Jenkins.XSTREAM2.toXMLUTF8(node, out);
+                            LOGGER.fine(out.toString("UTF-8"));
+                        } catch (IOException e) {
+                            LOGGER.log(Level.WARNING, "Failed to dump node config", e);
+                        }
+                    }
+                    c.setPendingDelete(true);
                 }
             }
-            c.setPendingDelete(true);
+        }
+
+
+        //case where the checkbox is checked
+        if ((oldestSlaveTermination == true)) {
+
+
+            //number of free executors in our VM template
+            int numOfFreeExec = JCloudsPreCreationThread.getNumOfFreeExec(templateName);
+
+            //number of executor required for our template
+            int numOfMinExec = c.getNode().getSlaveOptions().getNumExecutors() * node.getSlaveOptions().getInstancesMin();
+
+            //If oldest VM list is empty
+            if (listOldestVm.isEmpty()){
+                //Find the oldest VM for the template of the current Computer
+                oldestVmName = JCloudsPreCreationThread.getOldestVm(templateName, cloudName);
+                //New object
+                JCloudsPreCreationThread.OldestVM oldestVM = new JCloudsPreCreationThread.OldestVM(templateName, oldestVmName);
+                //Add the object to the oldest VM list
+                listOldestVm.add(oldestVM);
+            } else {
+
+                boolean templateInTheList = false;
+                for (int i = 0; i<listOldestVm.size(); i++){
+                    if (listOldestVm.get(i).getTemplateName().equals(templateName)){
+                        templateInTheList = true;
+                    }
+                }
+                //If the template is not in the oldestVMlist...
+                if (templateInTheList == false){
+                    //find the oldestVM for the template of the current computer
+                    oldestVmName = JCloudsPreCreationThread.getOldestVm(templateName, cloudName);
+                    //new object
+                    JCloudsPreCreationThread.OldestVM oldestVM = new JCloudsPreCreationThread.OldestVM(templateName, oldestVmName);
+                    //Add the object to the oldest VM list
+                    listOldestVm.add(oldestVM);
+                }
+            }
+
+
+            //If the number of free executors is higher than the number of minimum executors required
+            //and
+            //If the computer taken in parameter is the oldestVM
+
+            if (numOfFreeExec > numOfMinExec){
+                //If the current VM is the oldest
+                for (int i = 0; i<listOldestVm.size(); i++){
+                    if (templateName.equals(listOldestVm.get(i).templateName)){
+                        if (listOldestVm.get(i).getOldestVmName().equals(c.getName())){
+                            //We set the oldestVM to "PendingDelete"
+                            c.setPendingDelete(true);
+                            System.out.println(c.getName() + " Schedule for deleting");
+                            //Find the oldestVM for this template
+                            oldestVmName = JCloudsPreCreationThread.getOldestVm(templateName, cloudName);
+                            //Set the new oldest VM in the list
+                            listOldestVm.get(i).setOldestVmName(oldestVmName);
+                            System.out.println("The oldest VM for the template "+templateName+" is now "+oldestVmName);
+
+                        }
+                    }
+                }
+            }
+
         }
     }
 

--- a/src/main/java/jenkins/plugins/openstack/compute/SlaveOptions.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/SlaveOptions.java
@@ -37,6 +37,8 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.io.Serializable;
 
+import static java.lang.Boolean.TRUE;
+
 /**
  * Configured options for a slave to create.
  *
@@ -47,7 +49,7 @@ import java.io.Serializable;
  */
 public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
     private static final long serialVersionUID = -1L;
-    private static final SlaveOptions EMPTY = new SlaveOptions(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+    private static final SlaveOptions EMPTY = new SlaveOptions(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, false);
 
     // Provisioning attributes
     private /*final*/ @CheckForNull BootSource bootSource;
@@ -75,6 +77,7 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
 
     // Slave attributes
     private final Integer retentionTime;
+    private final boolean oldestSlaveTermination;
 
     // Replaced by BootSource
     @Deprecated private transient @CheckForNull String imageId;
@@ -143,6 +146,8 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
         return retentionTime;
     }
 
+    public boolean getOldestSlaveTermination() { return oldestSlaveTermination; }
+
     public SlaveOptions(Builder b) {
         this(
                 b.bootSource,
@@ -160,7 +165,8 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
                 b.jvmOptions,
                 b.fsRoot,
                 b.launcherFactory,
-                b.retentionTime
+                b.retentionTime,
+                b.oldestSlaveTermination
         );
     }
 
@@ -181,7 +187,8 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
             String jvmOptions,
             String fsRoot,
             LauncherFactory launcherFactory,
-            Integer retentionTime
+            Integer retentionTime,
+            boolean oldestSlaveTermination
     ) {
         this.bootSource = bootSource;
         this.hardwareId = Util.fixEmpty(hardwareId);
@@ -199,6 +206,7 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
         this.fsRoot = Util.fixEmpty(fsRoot);
         this.launcherFactory = launcherFactory;
         this.retentionTime = retentionTime;
+        this.oldestSlaveTermination = TRUE.equals(oldestSlaveTermination);
     }
 
     private Object readResolve() {
@@ -230,6 +238,7 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
                 .fsRoot(_override(this.fsRoot, o.fsRoot))
                 .launcherFactory(_override(this.launcherFactory, o.launcherFactory))
                 .retentionTime(_override(this.retentionTime, o.retentionTime))
+                .oldestSlaveTermination(_override(this.oldestSlaveTermination, o.oldestSlaveTermination))
                 .build()
         ;
     }
@@ -259,6 +268,7 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
                 .fsRoot(_erase(this.fsRoot, defaults.fsRoot))
                 .launcherFactory(_erase(this.launcherFactory, defaults.launcherFactory))
                 .retentionTime(_erase(this.retentionTime, defaults.retentionTime))
+                .oldestSlaveTermination(this.oldestSlaveTermination)
                 .build()
         ;
     }
@@ -289,6 +299,7 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
                 .append("fsRoot", fsRoot)
                 .append("launcherFactory", launcherFactory)
                 .append("retentionTime", retentionTime)
+                .append("oldestSlaveTermination", oldestSlaveTermination)
                 .toString()
         ;
     }
@@ -361,6 +372,7 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
                 .fsRoot(fsRoot)
                 .launcherFactory(launcherFactory)
                 .retentionTime(retentionTime)
+                .oldestSlaveTermination(oldestSlaveTermination)
         ;
     }
 
@@ -394,6 +406,7 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
 
         private @CheckForNull LauncherFactory launcherFactory;
         private @CheckForNull Integer retentionTime;
+        private boolean oldestSlaveTermination;
 
         public Builder() {}
 
@@ -480,6 +493,12 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
             this.retentionTime = retentionTime;
             return this;
         }
+
+        public @Nonnull Builder oldestSlaveTermination(boolean oldestSlaveTermination) {
+            this.oldestSlaveTermination = oldestSlaveTermination;
+            return this;
+        }
+
     }
 
     /**

--- a/src/main/resources/jenkins/plugins/openstack/compute/SlaveOptions/config.jelly
+++ b/src/main/resources/jenkins/plugins/openstack/compute/SlaveOptions/config.jelly
@@ -63,6 +63,9 @@
                     <f:entry title="Retention Time" field="retentionTime">
                         <f:number checkMethod="post"/>
                     </f:entry>
+                    <f:entry title="Oldest slave termination" field="oldestSlaveTermination" description="If checked, when we will have to much free executors, the oldest VM will goes to schedule for termination state">
+                        <f:checkbox />
+                    </f:entry>
                     <f:dropdownDescriptorSelector field="launcherFactory" title="Connection type"/>
                 </f:section>
 

--- a/src/test/java/jenkins/plugins/openstack/PluginTestRule.java
+++ b/src/test/java/jenkins/plugins/openstack/PluginTestRule.java
@@ -114,7 +114,7 @@ public final class PluginTestRule extends JenkinsRule {
         }
         return new SlaveOptions(
                 new BootSource.VolumeSnapshot("id"), "hw", "nw1,mw2", "dummyUserDataId", 1, 2, "pool", "sg", "az", 1, null, 10,
-                "jvmo", "fsRoot", LauncherFactory.JNLP.JNLP, 1
+                "jvmo", "fsRoot", LauncherFactory.JNLP.JNLP, 1, false
         );
     }
 

--- a/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudTest.java
@@ -151,10 +151,10 @@ public class JCloudsCloudTest {
 
         JCloudsSlaveTemplate template = new JCloudsSlaveTemplate("template", "label", new SlaveOptions(
                 new BootSource.Image("iid"), "hw", "nw", "ud", 1, 0, "public", "sg", "az", 2, "kp", 3, "jvmo", "fsRoot", LauncherFactory.JNLP.JNLP, 4
-        ));
+        , false));
         JCloudsCloud cloud = new JCloudsCloud("openstack", "endPointUrl", false,"zone", new SlaveOptions(
                 new BootSource.VolumeSnapshot("vsid"), "HW", "NW", "UD", 6, 4, null, "SG", "AZ", 7, "KP", 8, "JVMO", "FSrOOT", new LauncherFactory.SSH("cid"), 9
-        ), Collections.singletonList(template),openstackAuth);
+        , false), Collections.singletonList(template),openstackAuth);
         j.jenkins.clouds.add(cloud);
 
         JenkinsRule.WebClient wc = j.createWebClient();

--- a/src/test/java/jenkins/plugins/openstack/compute/SlaveOptionsTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/SlaveOptionsTest.java
@@ -90,7 +90,7 @@ public class SlaveOptionsTest {
         SlaveOptions nulls = SlaveOptions.empty();
         SlaveOptions emptyStrings = new SlaveOptions(
                 null, "", "", "", null, null, "", "", "", null, "", null, "", "", null, null
-        );
+        , false);
         SlaveOptions emptyBuilt = SlaveOptions.builder()
                 .hardwareId("")
                 .networkId("")


### PR DESCRIPTION
This new feature can be enabled with a checkbox for each template. It schedules for termination the oldest VM for each template when it’s possible (ie: There are more free executors than the minimum of instances multiplied by the number of executors defined in template parameters).
