### PR TITLE
Consider IP addresses without an explicit type as fixed

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
@@ -655,7 +655,7 @@ public class Openstack {
                             floatingIPv6 = address;
                         }
                     }
-                } else  if (Objects.equals(type, "fixed")) {
+                } else {
                     if (version == 4) {
                         if (fixedIPv4 == null) {
                             fixedIPv4 = address;

--- a/src/test/java/jenkins/plugins/openstack/PluginTestRule.java
+++ b/src/test/java/jenkins/plugins/openstack/PluginTestRule.java
@@ -308,6 +308,11 @@ public final class PluginTestRule extends JenkinsRule {
             @Override public void apply(@Nonnull MockServerBuilder serverBuilder, @Nonnull AtomicInteger cnt) {
                 serverBuilder.withFixedIPv6("4343::" + cnt.incrementAndGet());
             }
+        },
+        FIXED_4_NO_EXPLICIT_TYPE {
+            @Override public void apply(@Nonnull MockServerBuilder serverBuilder, @Nonnull AtomicInteger cnt) {
+                serverBuilder.withFixedIPv4WithoutExplicitType("43.43.43." + cnt.incrementAndGet());
+            }
         };
 
         public abstract void apply(@Nonnull MockServerBuilder serverBuilder, @Nonnull AtomicInteger sequence);
@@ -481,6 +486,10 @@ public final class PluginTestRule extends JenkinsRule {
 
         public MockServerBuilder withFixedIPv6(String ip) {
             return withAddress(ip, 6, "fixed");
+        }
+
+        public MockServerBuilder withFixedIPv4WithoutExplicitType(String ip) {
+            return withAddress(ip, 4, null);
         }
 
         public MockServerBuilder withAddress(String ip, int i, String fixed) {

--- a/src/test/java/jenkins/plugins/openstack/compute/ProvisioningTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/ProvisioningTest.java
@@ -430,6 +430,13 @@ public class ProvisioningTest {
     }
 
     @Test
+    public void findFixedIpv4WhenNoExplicitTypeIsGiven() throws Exception {
+        verifyPreferredAddressUsed("43.43.43.", Arrays.asList(
+                NetworkAddress.FIXED_4_NO_EXPLICIT_TYPE
+        ));
+    }
+
+    @Test
     public void failIfNoAccessIpFound() {
         try {
             verifyPreferredAddressUsed("Muahaha", Collections.emptyList());


### PR DESCRIPTION
Issue has been found while provisionning servers with Rackspace.
The given set of addresses looks like that:
```
[
    [NovaAddress{address=10.181.64.154, version=4, }],
    [NovaAddress{address=2a00:1a48:7807:101:ae76:4eff:fe08:487, version=6, }, NovaAddress{address=134.213.24.184, version=4, }]
]
```

Since there is no explicit type, the plugin fails to find a valid IP
and the provisioning of the agent in Jenkins is not successful.

The explicit verification of the type seems to have been introduced with
a refectoring 84900e383bd16de327d9fe3075d4a7d694a49418.