### PR TITLE
Fix flakey test JCloudsRetentionStrategyTest.doNotDeleteSlavePutOfflineByUser

### DIFF
--- a/src/test/java/jenkins/plugins/openstack/compute/JCloudsRetentionStrategyTest.java
+++ b/src/test/java/jenkins/plugins/openstack/compute/JCloudsRetentionStrategyTest.java
@@ -142,7 +142,7 @@ public class JCloudsRetentionStrategyTest {
 
         computer.setTemporarilyOffline(false, null);
 
-        checkAfter(computer, 60*1000);
+        checkAfter(computer, 61*1000);
 
         assertTrue(computer.isPendingDelete());
     }


### PR DESCRIPTION
Seems to fail most of the time, enough that even de-flaking doesn't let it pass reliably.
My guess is that it's relying on test code taking under 1ms to execute, which doesn't happen often.
Raising timeout from "1 minute" (the exact retention time configured) to "1 minute + 1 second" seems to fix this.