### PR TITLE
Failing to set name of Volume we booted from is no longer fatal

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/slaveopts/BootSource.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/slaveopts/BootSource.java
@@ -430,7 +430,17 @@ public abstract class BootSource extends AbstractDescribableImpl<BootSource> imp
                     + name + (instanceVolumeSnapshotId == null ? "" : " (" + instanceVolumeSnapshotId + ")") + ".";
             for (final String volumeId : volumeIds) {
                 final String newVolumeName = instanceName + '[' + (i++) + ']';
-                openstack.setVolumeNameAndDescription(volumeId, newVolumeName, newVolumeDescription);
+                try {
+                    openstack.setVolumeNameAndDescription(volumeId, newVolumeName, newVolumeDescription);
+                } catch (Openstack.ActionFailed ex) {
+                    /*
+                     * Some versions of OpenStack work better than others. Not all will accept this
+                     * operation. However, a failure to set the name and description is purely
+                     * cosmetic and does not affect our ability to use the instance, so we log the
+                     * problem and carry on.
+                     */
+                    LOGGER.warning("Unable to set volume " + volumeId + " name and description: " + ex.getMessage());
+                }
             }
         }
 


### PR DESCRIPTION
If we boot from a VolumeSnaphot, the Instance has a Volume attached to it, but OpenStack doesn't automatically set its name and it sometimes forgets to remove it with the Instance, so the plugin sets the name to make it easier for humans to figure out who owns what Volume.
... *however* this doesn't always work with all versions of OpenStack (see #277) and it's better that we live without this naming than fail to work at all, so we should log this error instead of letting it escape.
