### PR TITLE
Bump version of openstack4j from 3.3 to 3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
         <guava.version>20.0</guava.version> <!-- version compatible with openstack4j -->
         <jsr305.version>1.3.9</jsr305.version>
-        <openstack4j.version>3.3</openstack4j.version>
+        <openstack4j.version>3.4</openstack4j.version>
     </properties>
 
     <developers>


### PR DESCRIPTION
Issue #277 was addressed by fixing openstack4j, which has been done but now we need this code to use the fixed version.
The fixed version has now been released: https://github.com/openstack4j/openstack4j/commit/90f8ec03c87727a0ef568df8c9ded48377410440

