### PR TITLE
Upgrade to use jcasc test harness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.47</version>
+        <version>3.55</version>
     </parent>
 
     <artifactId>openstack-cloud</artifactId>
@@ -24,6 +24,7 @@
         <guava.version>20.0</guava.version> <!-- version compatible with openstack4j -->
         <jsr305.version>1.3.9</jsr305.version>
         <openstack4j.version>3.4</openstack4j.version>
+        <jackson.version>2.10.2</jackson.version>
     </properties>
 
     <developers>
@@ -33,6 +34,26 @@
           <email>ogondza@gmail.com</email>
         </developer>
     </developers>
+
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+          <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+          <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>com.fasterxml.jackson.dataformat</groupId>
+          <artifactId>jackson-dataformat-yaml</artifactId>
+          <version>${jackson.version}</version>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -129,14 +150,14 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.23</version>
+            <version>1.24</version>
         </dependency>
 
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
-            <version>1.3</version>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -186,23 +207,16 @@
         </dependency>
 
         <dependency>
-            <artifactId>configuration-as-code</artifactId>
             <groupId>io.jenkins</groupId>
-            <version>1.9</version>
+            <artifactId>configuration-as-code</artifactId>
+            <version>1.35</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <artifactId>configuration-as-code-support</artifactId>
             <groupId>io.jenkins.configuration-as-code</groupId>
-            <version>1.9</version>
+            <artifactId>test-harness</artifactId>
+            <version>1.35</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <artifactId>configuration-as-code</artifactId>
-            <groupId>io.jenkins</groupId>
-            <version>1.9</version>
-            <scope>test</scope>
-            <type>test-jar</type>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.18</version>
+            <version>2.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <url>https://github.com/jenkinsci/openstack-cloud-plugin</url>
 
     <properties>
-        <jenkins.version>2.121</jenkins.version>
+        <jenkins.version>2.138.4</jenkins.version>
         <java.level>8</java.level>
         <concurrency>1C</concurrency>
         <surefire.useFile>false</surefire.useFile>


### PR DESCRIPTION
JCasc had to create a new dependency that wasn't a `tests` classifier because maven doesn't allow you to bring dependencies through classifiers.

Upgrading here so that PCT works again,

Tracking:
https://github.com/jenkinsci/bom/pull/164

Note: We'll need a release for PCT please