### PR TITLE
Prevent unfriendly NPE when VolumeSnapshot not found

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/slaveopts/BootSource.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/slaveopts/BootSource.java
@@ -397,7 +397,19 @@ public abstract class BootSource extends AbstractDescribableImpl<BootSource> imp
             super.setServerBootSource(builder, os);
             final List<String> matchingIds = getDescriptor().findMatchingIds(os, name);
             final String id = selectIdFromListAndLogProblems(matchingIds, name, "VolumeSnapshots");
-            final String volumeSnapshotDescriptionOrNull = os.getVolumeSnapshotDescription(id);
+            String volumeSnapshotDescriptionOrNull = null;
+            try {
+                volumeSnapshotDescriptionOrNull = os.getVolumeSnapshotDescription(id);
+            } catch (RuntimeException ex) {
+                /*
+                 * This can throw, e.g. a NPE there is no VolumeSnapshot with that id. However,
+                 * a failure to get the description is purely cosmetic and a failure to find the
+                 * VolumeSnapshot would be better logged later on with a
+                 * "there's no volume snapshot of that name" error, so we log any exception we
+                 * get here and carry on, letting actual problems throw later.
+                 */
+                LOGGER.warning("Unable to get volume " + id + " description: " + ex.getMessage());
+            }
             final BlockDeviceMappingBuilder volumeBuilder = Builders.blockDeviceMapping()
                     .sourceType(BDMSourceType.SNAPSHOT)
                     .destinationType(BDMDestType.VOLUME)


### PR DESCRIPTION
If we're booting from a VolumeSnapshot, but the specified VolumeSnapshot does not exist, what we _want_ to happen is for the user to get a nice "There's no VolumeSnapshot called 'foo'" error reported (in the logs etc).
At present, what we actually get is an unhelpful NullPointerException:
```
java.lang.NullPointerException
	at jenkins.plugins.openstack.compute.internal.Openstack.getVolumeSnapshotDescription(Openstack.java:442)
	at jenkins.plugins.openstack.compute.slaveopts.BootSource$VolumeSnapshot.setServerBootSource(BootSource.java:400)
	at jenkins.plugins.openstack.compute.JCloudsSlaveTemplate.provisionServer(JCloudsSlaveTemplate.java:308)
	at jenkins.plugins.openstack.compute.JCloudsSlaveTemplate.provisionSlave(JCloudsSlaveTemplate.java:234)
	at jenkins.plugins.openstack.compute.JCloudsCloud$NodeCallable.makeNewSlaveNode(JCloudsCloud.java:395)
	at jenkins.plugins.openstack.compute.JCloudsCloud$NodeCallable.call(JCloudsCloud.java:387)
	at jenkins.plugins.openstack.compute.JCloudsCloud$NodeCallable.call(JCloudsCloud.java:373)
	at jenkins.util.ContextResettingExecutorService$2.call(ContextResettingExecutorService.java:46)
	at jenkins.security.ImpersonatingExecutorService$2.call(ImpersonatingExecutorService.java:71)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
...because we get one of those if we try to read the description of a non-existent VolumeSnapshot, and we try to read the description of the VolumeSnapshot we're going to boot from before we try booting from it.

This PR catches (and logs, much like we did in #278) the NPE, allowing the instance-creation to continue on until the OpenStack server throws us a much more user-friendly "can't do that" exception.
We still can't boot up an instance, but at least we'll get a much nicer explanation of why we can't do that (telling the user that it's their fault) instead of a NPE that makes it look like a plugin bug.