### PR TITLE
Degrade gracefully in case the network-ip-availability API is not available

### DIFF
--- a/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
@@ -427,6 +427,11 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
         }
 
         Map<Network, Integer> capacities = openstack.getNetworksCapacity(osNetworksById);
+        if (capacities.isEmpty()) {
+            LOGGER.warning("OpenStack network-ip-availability endpoint is inaccessible, unable to balance the load for " + spec);
+            // Return first of the alternatives
+            return declared.stream().map(l -> l.get(0)).map(RESOLVE_NAMES_TO_IDS).collect(Collectors.toList());
+        }
 
         ArrayList<Network> ret = new ArrayList<>(declared.size());
         for (List<String> alternativeList : declared) { // All networks to connect to

--- a/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
+++ b/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
@@ -211,8 +211,14 @@ public class Openstack {
 
     /**
      * For every network requested, return mapping of network and number of available fixed addresses.
+     *
+     * Note the network-ip-availability is usually available for admins only so the method may return <tt>null</tt> in that case.
+     *
+     * @return Map of requested networks and their free capacity. Might be empty.
      */
-    public Map<Network, Integer> getNetworksCapacity(Map<String, Network> declaredNetworks) {
+    public @Nonnull Map<Network, Integer> getNetworksCapacity(@Nonnull Map<String, Network> declaredNetworks) {
+        if (declaredNetworks.isEmpty()) throw new IllegalArgumentException("No request networks provided");
+
         List<String> declaredIds = declaredNetworks.values().stream().map(Network::getId).collect(Collectors.toList());
 
         List<? extends NetworkIPAvailability> networkIPAvailabilities = clientProvider.get().networking().networkIPAvailability().get();


### PR DESCRIPTION
The API is by default only available to Admin. Make sure this does not blow up when not configured accordingly.