### PR TITLE
corrected error passing private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ credentials:
               privateKeySource:
                 directEntry:
                   # Do not hardcode plaintext secrets for real world declarations!
-                  privateKey: >
+                  privateKey: |
                     -----BEGIN OPENSSH PRIVATE KEY-----
                     b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABFwAAAAdzc2gtcn
                     NhAAAAAwEAAQAAAQEAleOyx/pWbWBWrKOXyDpXio33Y6jAXdAi2mqo1nKIcIX75U71WxcR

--- a/src/test/resources/jenkins/plugins/openstack/JcascTest/jcasc.yaml
+++ b/src/test/resources/jenkins/plugins/openstack/JcascTest/jcasc.yaml
@@ -108,7 +108,7 @@ credentials:
               privateKeySource:
                 directEntry:
                   # Do not hardcode plaintext secrets for real world declarations!
-                  privateKey: >
+                  privateKey: |
                     -----BEGIN OPENSSH PRIVATE KEY-----
                     b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABFwAAAAdzc2gtcn
                     NhAAAAAwEAAQAAAQEAleOyx/pWbWBWrKOXyDpXio33Y6jAXdAi2mqo1nKIcIX75U71WxcR


### PR DESCRIPTION
`>` does not work and will brake the import. `|` is the correct symbol to use. 

This can easily be tested by adding a SSH key via JCasC plugin to Jenkins and later on export it via the script-console

`println(hudson.util.Secret.decrypt("{XXX=}"))`

In case with `>` output is broken. If a key is added with `|`, the key is printed out properly again.

Have had the same issue while playing around with the JCasC plugin.