### PR TITLE
Fix typo: Enable > Unable

### DIFF
--- a/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsCleanupThread.java
+++ b/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsCleanupThread.java
@@ -66,7 +66,7 @@ public final class JCloudsCleanupThread extends AsyncPeriodicWork {
         } catch (JCloudsCloud.LoginFailure ex) {
             LOGGER.log(Level.WARNING, "Unable to authenticate: " + ex.getMessage());
         } catch (Throwable ex) {
-            LOGGER.log(Level.SEVERE, "Enable to perform the cleanup", ex);
+            LOGGER.log(Level.SEVERE, "Unable to perform the cleanup", ex);
         }
     }
 


### PR DESCRIPTION
Make the logs more clear when Jenkins is unable to clean up OpenStack
instances.

Signed-off-by: Major Hayden <major@redhat.com>