### PR TITLE
Add filter and default override for expired/not found images

### DIFF
--- a/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
+++ b/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
@@ -124,7 +124,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
                 lf = LauncherFactory.JNLP.JNLP;
             }
 
-            BootSource.Image bs = imageId == null ? null : new BootSource.Image(imageId);
+            BootSource.Image bs = imageId == null ? null : new BootSource.Image(imageId, null, false);
             slaveOptions = SlaveOptions.builder().bootSource(bs).hardwareId(hardwareId).numExecutors(Integer.getInteger(numExecutors)).jvmOptions(jvmOptions).userDataId(userDataId)
                     .fsRoot(fsRoot).retentionTime(overrideRetentionTime).keyPairName(keyPairName).networkId(networkId).securityGroups(securityGroups)
                     .launcherFactory(lf).availabilityZone(availabilityZone).build()

--- a/plugin/src/main/java/jenkins/plugins/openstack/compute/SlaveOptions.java
+++ b/plugin/src/main/java/jenkins/plugins/openstack/compute/SlaveOptions.java
@@ -228,7 +228,7 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
 
     private Object readResolve() {
         if (bootSource == null && imageId != null) {
-            bootSource = new BootSource.Image(imageId);
+            bootSource = new BootSource.Image(imageId, null, false);
         }
         imageId = null;
         return this;

--- a/plugin/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/Image/config.jelly
+++ b/plugin/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/Image/config.jelly
@@ -3,4 +3,10 @@
     <f:entry title="Name" field="name">
         <f:select checkMethod="post"/>
     </f:entry>
+    <f:entry title="Name filter Regexp" field="nameFilterRegexp">
+       <f:textbox checkMethod="post"/>
+    </f:entry>
+    <f:entry title="Use first available, if selected not found" field="overrideNotFoundImage">
+           <f:checkbox/>
+     </f:entry>
 </j:jelly>

--- a/plugin/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/Image/help-nameFilterRegexp.html
+++ b/plugin/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/Image/help-nameFilterRegexp.html
@@ -1,0 +1,5 @@
+<div>
+  Filter to list available image names based on RegExp.
+  <br/>
+  The name list will be populated with the names of images that matches provided RegExp.
+</div>

--- a/plugin/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/Image/help-overrideNotFoundImage.html
+++ b/plugin/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/Image/help-overrideNotFoundImage.html
@@ -1,0 +1,5 @@
+<div>
+  Override selected name, if not found or no longer available on server.
+  <br/>
+  Note: If the filter RegExp is ambiguous, i.e. there are multiple images matches filter regexp, then first matched will be used.
+</div>

--- a/plugin/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/VolumeFromImage/config.jelly
+++ b/plugin/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/VolumeFromImage/config.jelly
@@ -6,4 +6,10 @@
     <f:entry title="Volume Size in GB" field="volumeSize">
         <f:number clazz="required positive-number"/>
     </f:entry>
+    <f:entry title="Name filter Regexp" field="nameFilterRegexp">
+        <f:textbox checkMethod="post"/>
+    </f:entry>
+    <f:entry title="Use first available, if selected not found" field="overrideNotFoundImage">
+        <f:checkbox/>
+    </f:entry>
 </j:jelly>

--- a/plugin/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/VolumeFromImage/help-nameFilterRegexp.html
+++ b/plugin/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/VolumeFromImage/help-nameFilterRegexp.html
@@ -1,0 +1,5 @@
+<div>
+  Filter to list available image names based on RegExp.
+  <br/>
+  The name list will be populated with the names of images that matches provided RegExp.
+</div>

--- a/plugin/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/VolumeFromImage/help-overrideNotFoundImage.html
+++ b/plugin/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/VolumeFromImage/help-overrideNotFoundImage.html
@@ -1,0 +1,5 @@
+<div>
+  Override selected name, if not found or no longer available on server.
+  <br/>
+  Note: If the filter RegExp is ambiguous, i.e. there are multiple images matches filter regexp, then first matched will be used.
+</div>

--- a/plugin/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/VolumeSnapshot/config.jelly
+++ b/plugin/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/VolumeSnapshot/config.jelly
@@ -3,4 +3,10 @@
     <f:entry title="Name" field="name">
         <f:select checkMethod="post"/>
     </f:entry>
+    <f:entry title="Name filter Regexp" field="nameFilterRegexp">
+        <f:textbox checkMethod="post"/>
+    </f:entry>
+    <f:entry title="Use first available, if selected not found" field="overrideNotFoundImage">
+        <f:checkbox/>
+    </f:entry>
 </j:jelly>

--- a/plugin/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/VolumeSnapshot/help-nameFilterRegexp.html
+++ b/plugin/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/VolumeSnapshot/help-nameFilterRegexp.html
@@ -1,0 +1,5 @@
+<div>
+  Filter to list available image names based on RegExp.
+  <br/>
+  The name list will be populated with the names of images that matches provided RegExp.
+</div>

--- a/plugin/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/VolumeSnapshot/help-overrideNotFoundImage.html
+++ b/plugin/src/main/resources/jenkins/plugins/openstack/compute/slaveopts/BootSource/VolumeSnapshot/help-overrideNotFoundImage.html
@@ -1,0 +1,5 @@
+<div>
+  Override selected name, if not found or no longer available on server.
+  <br/>
+  Note: If the filter RegExp is ambiguous, i.e. there are multiple images matches filter regexp, then first matched will be used.
+</div>

--- a/plugin/src/test/java/jenkins/plugins/openstack/PluginTestRule.java
+++ b/plugin/src/test/java/jenkins/plugins/openstack/PluginTestRule.java
@@ -123,7 +123,7 @@ public final class PluginTestRule extends JenkinsRule {
             dummyUserData("dummyUserDataId");
         }
         return new SlaveOptions(
-                new BootSource.VolumeSnapshot("id"), "hw", "nw1,mw2", "dummyUserDataId", 1, 2, "pool", "sg", "az", 1, null, 10,
+                new BootSource.VolumeSnapshot("id", null, false), "hw", "nw1,mw2", "dummyUserDataId", 1, 2, "pool", "sg", "az", 1, null, 10,
                 "jvmo", "fsRoot", LauncherFactory.JNLP.JNLP, mkListOfNodeProperties(1, 2), 1, null
         );
     }
@@ -173,7 +173,7 @@ public final class PluginTestRule extends JenkinsRule {
 
         // Use some real-looking values preserving defaults to make sure plugin works with them
         return JCloudsCloud.DescriptorImpl.getDefaultOptions().getBuilder()
-                .bootSource(new BootSource.Image("dummyImageId"))
+                .bootSource(new BootSource.Image("dummyImageId", null, false))
                 .hardwareId("dummyHardwareId")
                 .networkId("dummyNetworkId")
                 .userDataId("dummyUserDataId")

--- a/plugin/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudTest.java
+++ b/plugin/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudTest.java
@@ -152,10 +152,10 @@ public class JCloudsCloudTest {
         String openstackAuth = j.dummyCredentials();
 
         JCloudsSlaveTemplate template = new JCloudsSlaveTemplate("template", "label", new SlaveOptions(
-                new BootSource.Image("iid"), "hw", "nw", "ud", 1, 0, "public", "sg", "az", 2, "kp", 3, "jvmo", "fsRoot", LauncherFactory.JNLP.JNLP, null, 4, false
+                new BootSource.Image("iid", null, false), "hw", "nw", "ud", 1, 0, "public", "sg", "az", 2, "kp", 3, "jvmo", "fsRoot", LauncherFactory.JNLP.JNLP, null, 4, false
         ));
         JCloudsCloud cloud = new JCloudsCloud("openstack", "endPointUrl", false,"zone", new SlaveOptions(
-                new BootSource.VolumeSnapshot("vsid"), "HW", "NW", "UD", 6, 4, null, "SG", "AZ", 7, "KP", 8, "JVMO", "FSrOOT", new LauncherFactory.SSH("cid"), null, 9, false
+                new BootSource.VolumeSnapshot("vsid", null, false), "HW", "NW", "UD", 6, 4, null, "SG", "AZ", 7, "KP", 8, "JVMO", "FSrOOT", new LauncherFactory.SSH("cid"), null, 9, false
         ), Collections.singletonList(template),openstackAuth);
         j.jenkins.clouds.add(cloud);
 

--- a/plugin/src/test/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplateTest.java
+++ b/plugin/src/test/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplateTest.java
@@ -109,7 +109,7 @@ public class JCloudsSlaveTemplateTest {
     @Test
     public void eraseDefaults() {
         SlaveOptions cloudOpts = dummySlaveOptions(); // Make sure nothing collides with defaults
-        SlaveOptions templateOpts = cloudOpts.getBuilder().bootSource(new BootSource.Image("id")).availabilityZone("other").build();
+        SlaveOptions templateOpts = cloudOpts.getBuilder().bootSource(new BootSource.Image("id", null, false)).availabilityZone("other").build();
         assertEquals(cloudOpts.getHardwareId(), templateOpts.getHardwareId());
 
         JCloudsSlaveTemplate template = new JCloudsSlaveTemplate(
@@ -124,7 +124,7 @@ public class JCloudsSlaveTemplateTest {
         );
 
         assertEquals(cloudOpts, cloud.getRawSlaveOptions());
-        assertEquals(SlaveOptions.builder().bootSource(new BootSource.Image("id")).availabilityZone("other").build(), template.getRawSlaveOptions());
+        assertEquals(SlaveOptions.builder().bootSource(new BootSource.Image("id", null, false)).availabilityZone("other").build(), template.getRawSlaveOptions());
     }
 
     @Test
@@ -189,7 +189,7 @@ public class JCloudsSlaveTemplateTest {
     public void bootFromVolumeSnapshot() {
         final String volumeSnapshotName = "MyVolumeSnapshot";
         final String volumeSnapshotId = "vs-123-id";
-        final SlaveOptions opts = dummySlaveOptions().getBuilder().bootSource(new VolumeSnapshot(volumeSnapshotName)).build();
+        final SlaveOptions opts = dummySlaveOptions().getBuilder().bootSource(new VolumeSnapshot(volumeSnapshotName, null, false)).build();
         final JCloudsSlaveTemplate instance = j.dummySlaveTemplate(opts, "a");
         final JCloudsCloud cloud = j.configureSlaveProvisioningWithFloatingIP(j.dummyCloud(instance));
         final Openstack mockOs = cloud.getOpenstack();
@@ -206,7 +206,7 @@ public class JCloudsSlaveTemplateTest {
          */
         final String volumeSnapshotName = "MyNonexistentVolumeSnapshot";
         final String volumeSnapshotId = volumeSnapshotName;
-        final SlaveOptions opts = dummySlaveOptions().getBuilder().bootSource(new VolumeSnapshot(volumeSnapshotName)).build();
+        final SlaveOptions opts = dummySlaveOptions().getBuilder().bootSource(new VolumeSnapshot(volumeSnapshotName, null, false)).build();
         final JCloudsSlaveTemplate instance = j.dummySlaveTemplate(opts, "b");
         final JCloudsCloud cloud = j.configureSlaveProvisioningWithFloatingIP(j.dummyCloud(instance));
         final Openstack mockOs = cloud.getOpenstack();
@@ -230,7 +230,7 @@ public class JCloudsSlaveTemplateTest {
          */
         final String volumeSnapshotName = "MyOtherVolumeSnapshot";
         final String volumeSnapshotId = "vs-345-id";
-        final SlaveOptions opts = dummySlaveOptions().getBuilder().bootSource(new VolumeSnapshot(volumeSnapshotName)).build();
+        final SlaveOptions opts = dummySlaveOptions().getBuilder().bootSource(new VolumeSnapshot(volumeSnapshotName, null, false)).build();
         final JCloudsSlaveTemplate instance = j.dummySlaveTemplate(opts, "b");
         final JCloudsCloud cloud = j.configureSlaveProvisioningWithFloatingIP(j.dummyCloud(instance));
         final Openstack mockOs = cloud.getOpenstack();
@@ -278,7 +278,7 @@ public class JCloudsSlaveTemplateTest {
 
     @Test
     public void bootFromImageVolume() {
-        final SlaveOptions opts = dummySlaveOptions().getBuilder().bootSource(new BootSource.VolumeFromImage("src_img_id", 42)).build();
+        final SlaveOptions opts = dummySlaveOptions().getBuilder().bootSource(new BootSource.VolumeFromImage("src_img_id", 42, null, false)).build();
         final JCloudsSlaveTemplate template = j.dummySlaveTemplate(opts, "label");
         final JCloudsCloud cloud = j.configureSlaveProvisioningWithFloatingIP(j.dummyCloud(template));
         final Openstack os = cloud.getOpenstack();
@@ -298,8 +298,33 @@ public class JCloudsSlaveTemplateTest {
     }
 
     @Test
+    public void bootFromImageVolumeImageNotFoundAndOverrideByFilter() {
+        final SlaveOptions opts = dummySlaveOptions().getBuilder().bootSource(new BootSource.VolumeFromImage("src_img_id", 42, "default.*", true)).build();
+        final JCloudsSlaveTemplate template = j.dummySlaveTemplate(opts, "label");
+        final JCloudsCloud cloud = j.configureSlaveProvisioningWithFloatingIP(j.dummyCloud(template));
+        final Openstack os = cloud.getOpenstack();
+
+        when(os.getImageIdsFor("src_img_id")).thenReturn(Collections.EMPTY_LIST);
+        when(os.getImageIdsFor("default_image")).thenReturn(Collections.singletonList("default_image"));
+        when(os.getImages()).thenReturn(Collections.singletonMap("default_image", null));
+
+        template.provisionServer(null, null);
+
+        ArgumentCaptor<ServerCreateBuilder> captor = ArgumentCaptor.forClass(ServerCreateBuilder.class);
+        verify(os, times(1)).bootAndWaitActive(captor.capture(), any(Integer.class));
+        NovaBlockDeviceMappingCreate blockDeviceMapping = getBlockDeviceMapping(captor.getValue());
+
+        assertThat(blockDeviceMapping.boot_index, equalTo(0));
+        assertThat(blockDeviceMapping.delete_on_termination, equalTo(true));
+        assertThat(blockDeviceMapping.uuid, equalTo("default_image"));
+        assertThat(blockDeviceMapping.source_type, equalTo(BDMSourceType.IMAGE));
+        assertThat(blockDeviceMapping.destination_type, equalTo(BDMDestType.VOLUME));
+        assertThat(blockDeviceMapping.volume_size, equalTo(42));
+    }
+
+    @Test
     public void allowToUseImageNameAsWellAsId() throws Exception {
-        SlaveOptions opts = j.defaultSlaveOptions().getBuilder().bootSource(new BootSource.Image("image-id")).build();
+        SlaveOptions opts = j.defaultSlaveOptions().getBuilder().bootSource(new BootSource.Image("image-id", null, false)).build();
         JCloudsCloud cloud = j.configureSlaveLaunchingWithFloatingIP(j.dummyCloud(j.dummySlaveTemplate(opts, "label")));
 
         Openstack os = cloud.getOpenstack();
@@ -319,7 +344,7 @@ public class JCloudsSlaveTemplateTest {
 
     @Test
     public void allowToUseVolumeSnapshotNameAsWellAsId() throws Exception {
-        SlaveOptions opts = j.defaultSlaveOptions().getBuilder().bootSource(new VolumeSnapshot("vs-id")).build();
+        SlaveOptions opts = j.defaultSlaveOptions().getBuilder().bootSource(new VolumeSnapshot("vs-id", "vs-.*", true)).build();
         JCloudsCloud cloud = j.configureSlaveLaunchingWithFloatingIP(j.dummyCloud(j.dummySlaveTemplate(opts, "label")));
 
         Openstack os = cloud.getOpenstack();

--- a/plugin/src/test/java/jenkins/plugins/openstack/compute/SlaveOptionsTest.java
+++ b/plugin/src/test/java/jenkins/plugins/openstack/compute/SlaveOptionsTest.java
@@ -23,7 +23,7 @@ public class SlaveOptionsTest {
         SlaveOptions dummySlaveOptions = PluginTestRule.dummySlaveOptions();
         SlaveOptions unmodified = dummySlaveOptions.override(SlaveOptions.empty());
 
-        assertEquals(new BootSource.VolumeSnapshot("id"), unmodified.getBootSource());
+        assertEquals(new BootSource.VolumeSnapshot("id", null, false), unmodified.getBootSource());
         assertEquals("hw", unmodified.getHardwareId());
         assertEquals("nw1,mw2", unmodified.getNetworkId());
         assertEquals("dummyUserDataId", unmodified.getUserDataId());
@@ -42,7 +42,7 @@ public class SlaveOptionsTest {
         assertEquals(1, (int) unmodified.getRetentionTime());
 
         SlaveOptions override = SlaveOptions.builder()
-                .bootSource(new BootSource.Image("iid"))
+                .bootSource(new BootSource.Image("iid", null, false))
                 .hardwareId("HW")
                 .networkId("NW")
                 .userDataId("UD")
@@ -63,7 +63,7 @@ public class SlaveOptionsTest {
         ;
         SlaveOptions overridden = PluginTestRule.dummySlaveOptions().override(override);
 
-        assertEquals(new BootSource.Image("iid"), overridden.getBootSource());
+        assertEquals(new BootSource.Image("iid", null, false), overridden.getBootSource());
         assertEquals("HW", overridden.getHardwareId());
         assertEquals("NW", overridden.getNetworkId());
         assertEquals("UD", overridden.getUserDataId());
@@ -84,8 +84,8 @@ public class SlaveOptionsTest {
 
     @Test
     public void eraseDefaults() {
-        SlaveOptions defaults = SlaveOptions.builder().bootSource(new BootSource.Image("ID")).hardwareId("hw").networkId(null).floatingIpPool("a").build();
-        SlaveOptions configured = SlaveOptions.builder().bootSource(new BootSource.Image("ID")).hardwareId("hw").networkId("MW").floatingIpPool("A").build();
+        SlaveOptions defaults = SlaveOptions.builder().bootSource(new BootSource.Image("ID", null, false)).hardwareId("hw").networkId(null).floatingIpPool("a").build();
+        SlaveOptions configured = SlaveOptions.builder().bootSource(new BootSource.Image("ID", null, false)).hardwareId("hw").networkId("MW").floatingIpPool("A").build();
 
         SlaveOptions actual = configured.eraseDefaults(defaults);
 

--- a/plugin/src/test/java/jenkins/plugins/openstack/compute/slaveopts/BootSourceTest.java
+++ b/plugin/src/test/java/jenkins/plugins/openstack/compute/slaveopts/BootSourceTest.java
@@ -71,28 +71,28 @@ public class BootSourceTest {
     @Test
     public void constructorInvariants() {
         try {
-            new BootSource.Image(null);
+            new BootSource.Image(null, null, false);
             fail();
         } catch (NullPointerException e) {
             assertThat(e.getMessage(), containsString("Image name missing"));
         }
 
         try {
-            new BootSource.VolumeSnapshot(null);
+            new BootSource.VolumeSnapshot(null, null, false);
             fail();
         } catch (NullPointerException e) {
             assertThat(e.getMessage(), containsString("Volume snapshot name missing"));
         }
 
         try {
-            new BootSource.VolumeFromImage(null, 1);
+            new BootSource.VolumeFromImage(null, 1, null, false);
             fail();
         } catch (NullPointerException e) {
             assertThat(e.getMessage(), containsString("Image name missing"));
         }
 
         try {
-            new BootSource.VolumeFromImage("foo", 0);
+            new BootSource.VolumeFromImage("foo", 0, null, false);
             fail();
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), containsString("Volume size must be positive, got 0"));
@@ -111,7 +111,34 @@ public class BootSourceTest {
 
         doReturn(Collections.singletonMap(imageName, Collections.singletonList(image))).when(os).getImages();
 
-        ListBoxModel list = id.doFillNameItems("", "OSurl", false, credentialsId, "OSzone");
+        ListBoxModel list = id.doFillNameItems("", "OSurl", false, credentialsId, "OSzone", null);
+        assertEquals(2, list.size());
+        assertEquals("First menu entry is 'nothing selected'", "", list.get(0).value);
+        ListBoxModel.Option item = list.get(1);
+        assertEquals("menu item name", imageName, item.name);
+        assertEquals("menu item value", imageName, item.value);
+    }
+
+    @Test
+    public void doFillImageNameItemsPopulatesImageNamesWithFilter() {
+        Image image = mock(Image.class);
+        when(image.getId()).thenReturn("image-id");
+        final String imageName = "image-name";
+        when(image.getName()).thenReturn(imageName);
+
+        Image imageFiltered = mock(Image.class);
+        when(imageFiltered.getId()).thenReturn("filtered-id");
+        final String imageFilteredName = "filtered-name";
+        when(imageFiltered.getName()).thenReturn(imageFilteredName);
+
+        Openstack os = j.fakeOpenstackFactory();
+        final String credentialsId = j.dummyCredentials();
+        Map<String, List> images = new HashMap();
+        images.put(imageName, Collections.singletonList(image));
+        images.put(imageFilteredName, Collections.singletonList(imageFiltered));
+        doReturn(images).when(os).getImages();
+
+        ListBoxModel list = id.doFillNameItems("", "OSurl", false, credentialsId, "OSzone", "image-.*");
         assertEquals(2, list.size());
         assertEquals("First menu entry is 'nothing selected'", "", list.get(0).value);
         ListBoxModel.Option item = list.get(1);
@@ -130,11 +157,39 @@ public class BootSourceTest {
         Openstack os = j.fakeOpenstackFactory();
         when(os.getVolumeSnapshots()).thenReturn(Collections.singletonMap("vs-name", Collections.singletonList(volumeSnapshot)));
 
-        ListBoxModel list = vsd.doFillNameItems("existing-vs-name", "OSurl", false, credentialsId, "OSzone");
+        ListBoxModel list = vsd.doFillNameItems("existing-vs-name", "OSurl", false, credentialsId, "OSzone", null);
         assertEquals(3, list.size());
         assertEquals("First menu entry is 'nothing selected'", "", list.get(0).value);
         assertEquals("Second menu entry is the VS OpenStack can see", "vs-name", list.get(1).name);
         assertEquals("Second menu entry is the VS OpenStack can see", "vs-name", list.get(1).value);
+        assertEquals("Third menu entry is the existing value", "existing-vs-name", list.get(2).name);
+        assertEquals("Third menu entry is the existing value", "existing-vs-name", list.get(2).value);
+    }
+
+    @Test
+    public void doFillSnapshotNameItemsPopulatesVolumeSnapshotNamesWithFilter() {
+        VolumeSnapshot volumeSnapshot = mock(VolumeSnapshot.class);
+        when(volumeSnapshot.getId()).thenReturn("vs-id");
+        when(volumeSnapshot.getName()).thenReturn("vs-name");
+        when(volumeSnapshot.getStatus()).thenReturn(Volume.Status.AVAILABLE);
+
+        VolumeSnapshot volumeSnapshotFiltered = mock(VolumeSnapshot.class);
+        when(volumeSnapshotFiltered.getId()).thenReturn("vs-filtered-id");
+        when(volumeSnapshotFiltered.getName()).thenReturn("vs-filtered-name");
+        when(volumeSnapshotFiltered.getStatus()).thenReturn(Volume.Status.AVAILABLE);
+        final String credentialsId = j.dummyCredentials();
+
+        Openstack os = j.fakeOpenstackFactory();
+        Map<String, List<VolumeSnapshot>> volumes = new HashMap();
+        volumes.put("vs-name", Collections.singletonList(volumeSnapshot));
+        volumes.put("vs-filtered-name", Collections.singletonList(volumeSnapshot));
+        when(os.getVolumeSnapshots()).thenReturn(volumes);
+
+        ListBoxModel list = vsd.doFillNameItems("existing-vs-name", "OSurl", false, credentialsId, "OSzone", "vs-filtered.*");
+        assertEquals(3, list.size());
+        assertEquals("First menu entry is 'nothing selected'", "", list.get(0).value);
+        assertEquals("Second menu entry is the VS OpenStack can see", "vs-filtered-name", list.get(1).name);
+        assertEquals("Second menu entry is the VS OpenStack can see", "vs-filtered-name", list.get(1).value);
         assertEquals("Third menu entry is the existing value", "existing-vs-name", list.get(2).name);
         assertEquals("Third menu entry is the existing value", "existing-vs-name", list.get(2).value);
     }
@@ -153,7 +208,7 @@ public class BootSourceTest {
         j.fakeOpenstackFactory(new Openstack(osClient));
         final String credentialsId = j.dummyCredentials();
 
-        ListBoxModel list = id.doFillNameItems("", "OSurl", false, credentialsId, "OSzone");
+        ListBoxModel list = id.doFillNameItems("", "OSurl", false, credentialsId, "OSzone", null);
         assertThat(list.get(0).name, list, Matchers.iterableWithSize(2));
         assertEquals(2, list.size());
         ListBoxModel.Option item = list.get(1);


### PR DESCRIPTION
Resolve: https://github.com/jenkinsci/openstack-cloud-plugin/issues/286

This change allow users to provide name filter(based on Java regexp), that will show only matched names in config. That is helpful for organizations that have many different OS images. Also introducing override provided name, if image was deprecated/removed from available list, first matched by filter will be selected, that helps prevent downtime when organizations do image rotations, and don't need to go to each jenkins and update image name.

All `BootSource`s are supported, except `Unspecified`.

UI Changes:
<img width="956" alt="Screen Shot 2020-09-27 at 11 37 16 AM" src="https://user-images.githubusercontent.com/60720002/94372841-f554fb80-00b5-11eb-9610-dd7408d699a4.png">
