### PR TITLE
Bump okhttp version

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -25,7 +25,7 @@
         <guava.version>20.0</guava.version> <!-- version compatible with openstack4j -->
         <jsr305.version>1.3.9</jsr305.version>
         <openstack4j.version>3.8</openstack4j.version>
-        <okhttp.version>3.9.1</okhttp.version>
+        <okhttp.version>3.14.9</okhttp.version>
     </properties>
 
     <developers>


### PR DESCRIPTION
otherwise plugin fails with newer versions of Java 1.8

the issue has been fixed here:
https://square.github.io/okhttp/changelog_3x/#version-3148