### PR TITLE
Do not rely on Jenkins url for resource identification

### DIFF
--- a/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlave.java
+++ b/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlave.java
@@ -59,7 +59,8 @@ public class JCloudsSlave extends AbstractCloudSlave implements TrackedItem {
 
     /** metadata fields that aren't worth showing to the user. */
     private static final List<String> HIDDEN_METADATA_VALUES = Arrays.asList(
-            Openstack.FINGERPRINT_KEY,
+            Openstack.FINGERPRINT_KEY_FINGERPRINT,
+            Openstack.FINGERPRINT_KEY_URL,
             JCloudsSlaveTemplate.OPENSTACK_CLOUD_NAME_KEY,
             JCloudsSlaveTemplate.OPENSTACK_TEMPLATE_NAME_KEY,
             ServerScope.METADATA_KEY

--- a/plugin/src/test/java/jenkins/plugins/openstack/PluginTestRule.java
+++ b/plugin/src/test/java/jenkins/plugins/openstack/PluginTestRule.java
@@ -91,6 +91,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.RETURNS_SMART_NULLS;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
@@ -374,7 +375,11 @@ public final class PluginTestRule extends JenkinsRule {
             Map<String, Network> nets = (Map<String, Network>) invocation.getArguments()[0];
             return nets.values().stream().collect(Collectors.toMap(n -> n, b -> 100));
         });
-        when(os.bootAndWaitActive(any(ServerCreateBuilder.class), any(Integer.class))).thenAnswer((Answer<Server>) invocation -> {
+        when(os.bootAndWaitActive(any(ServerCreateBuilder.class), any(Integer.class))).thenCallRealMethod();
+        doCallRealMethod().when(os).attachFingerprint(any(ServerCreateBuilder.class));
+        doCallRealMethod().when(os).instanceUrl();
+        doCallRealMethod().when(os).instanceFingerprint();
+        when(os._bootAndWaitActive(any(ServerCreateBuilder.class), any(Integer.class))).thenAnswer((Answer<Server>) invocation -> {
             ServerCreateBuilder builder = (ServerCreateBuilder) invocation.getArguments()[0];
 
             ServerCreate create = builder.build();
@@ -508,7 +513,6 @@ public final class PluginTestRule extends JenkinsRule {
             when(server.getStatus()).thenReturn(Server.Status.ACTIVE);
             when(server.getMetadata()).thenReturn(metadata);
             when(server.getOsExtendedVolumesAttached()).thenReturn(Collections.singletonList(UUID.randomUUID().toString()));
-            metadata.put("jenkins-instance", jenkins.getRootUrl()); // Mark the slave as ours
         }
 
         public MockServerBuilder name(String name) {

--- a/plugin/src/test/java/jenkins/plugins/openstack/compute/ProvisioningTest.java
+++ b/plugin/src/test/java/jenkins/plugins/openstack/compute/ProvisioningTest.java
@@ -7,7 +7,6 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Label;
 import hudson.model.Node;
-import hudson.model.Slave;
 import hudson.model.TaskListener;
 import hudson.node_monitors.DiskSpaceMonitorDescriptor;
 import hudson.plugins.sshslaves.SSHLauncher;
@@ -43,13 +42,16 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import static jenkins.plugins.openstack.compute.internal.Openstack.FINGERPRINT_KEY_FINGERPRINT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.iterableWithSize;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -299,10 +301,13 @@ public class ProvisioningTest {
         JCloudsSlaveTemplate template = j.dummySlaveTemplate("label");
         final JCloudsCloud cloud = j.configureSlaveProvisioningWithFloatingIP(j.dummyCloud(template));
 
+        assertThat(cloud.getOpenstack().instanceUrl(), not(emptyString()));
+        assertThat(cloud.getOpenstack().instanceFingerprint(), not(emptyString()));
+System.out.println(cloud.getOpenstack().instanceFingerprint());
         Server server = template.provisionServer(null, null);
         Map<String, String> m = server.getMetadata();
-
-        assertEquals(j.getURL().toExternalForm(), m.get(Openstack.FINGERPRINT_KEY));
+        assertEquals(cloud.getOpenstack().instanceUrl(), m.get(Openstack.FINGERPRINT_KEY_URL));
+        assertEquals(cloud.getOpenstack().instanceFingerprint(), m.get(FINGERPRINT_KEY_FINGERPRINT));
         assertEquals(cloud.name, m.get(JCloudsSlaveTemplate.OPENSTACK_CLOUD_NAME_KEY));
         assertEquals(template.getName(), m.get(JCloudsSlaveTemplate.OPENSTACK_TEMPLATE_NAME_KEY));
         assertEquals(new ServerScope.Node(server.getName()).getValue(), m.get(ServerScope.METADATA_KEY));

--- a/plugin/src/test/java/jenkins/plugins/openstack/compute/internal/FipScopeTest.java
+++ b/plugin/src/test/java/jenkins/plugins/openstack/compute/internal/FipScopeTest.java
@@ -34,14 +34,16 @@ import static org.mockito.Mockito.when;
 
 public class FipScopeTest {
 
-    private static final String FNGRPRNT = "https://some-quite-long-jenkins-url-to-make-sure-it-fits.acme.com:8080/jenkins";
-    public static final String REALISTIC_EXAMPLE
-            = "{ 'jenkins-instance': 'https://some-quite-long-jenkins-url-to-make-sure-it-fits.acme.com:8080/jenkins', 'jenkins-scope': 'server:d8eca2df-7795-4069-b2ef-1e2412491345' }";
+    private static final String URL = "https://some-quite-long-jenkins-url-to-make-sure-it-fits.acme.com:8080/jenkins";
+    private static final String FINGERPRINT = "3919bce9a2f5fc4f730bd6462e23454ecb1fb089";
+    public static final String LEGACY_DESCRIPTION = "{ 'jenkins-instance': 'https://some-quite-long-jenkins-url-to-make-sure-it-fits.acme.com:8080/jenkins', 'jenkins-scope': 'server:d8eca2df-7795-4069-b2ef-1e2412491345' }";
+    public static final String EXPECTED_DESCRIPTION = "{ 'jenkins-instance': 'https://some-quite-long-jenkins-url-to-make-sure-it-fits.acme.com:8080/jenkins', 'jenkins-identity': '3919bce9a2f5fc4f730bd6462e23454ecb1fb089', 'jenkins-scope': 'server:d8eca2df-7795-4069-b2ef-1e2412491345' }";
+    public static final String ABBREVIATED_DESCRIPTION = "{ 'jenkins-identity': '3919bce9a2f5fc4f730bd6462e23454ecb1fb089', 'jenkins-scope': 'server:d8eca2df-7795-4069-b2ef-1e2412491345' }";
 
     @Test
     public void getDescription() {
-        assertEquals(REALISTIC_EXAMPLE, FipScope.getDescription(FNGRPRNT, server("d8eca2df-7795-4069-b2ef-1e2412491345")));
-        assertThat("Possible length is larger than maximal size of FIP description", REALISTIC_EXAMPLE.length(), lessThanOrEqualTo(250));
+        assertEquals(EXPECTED_DESCRIPTION, FipScope.getDescription(URL, FINGERPRINT, server("d8eca2df-7795-4069-b2ef-1e2412491345")));
+        assertThat("Possible length is larger than maximal size of FIP description", EXPECTED_DESCRIPTION.length(), lessThanOrEqualTo(FipScope.MAX_DESCRIPTION_LENGTH));
     }
 
     private Server server(String id) {
@@ -52,13 +54,16 @@ public class FipScopeTest {
 
     @Test
     public void getServerId() {
-        assertEquals("d8eca2df-7795-4069-b2ef-1e2412491345", FipScope.getServerId(FNGRPRNT, REALISTIC_EXAMPLE));
+//        assertEquals("d8eca2df-7795-4069-b2ef-1e2412491345", FipScope.getServerId(URL, FINGERPRINT, EXPECTED_DESCRIPTION));
+        assertEquals("d8eca2df-7795-4069-b2ef-1e2412491345", FipScope.getServerId(URL, FINGERPRINT, LEGACY_DESCRIPTION));
+        assertEquals("d8eca2df-7795-4069-b2ef-1e2412491345", FipScope.getServerId(URL, FINGERPRINT, ABBREVIATED_DESCRIPTION));
 
-        assertNull(FipScope.getServerId(FNGRPRNT, "{ 'jenkins-instance': 'https://some.other.jenkins.io', 'jenkins-scope': 'server:d8eca2df-7795-4069-b2ef-1e2412491345' }"));
-        assertNull(FipScope.getServerId(FNGRPRNT, "{ [ 'not', 'the', 'json', 'you', 'expect' ] }"));
-        assertNull(FipScope.getServerId(FNGRPRNT, "[ 'not', 'the', 'json', 'you', 'expect' ]"));
-        assertNull(FipScope.getServerId(FNGRPRNT, "Human description"));
-        assertNull(FipScope.getServerId(FNGRPRNT, ""));
-        assertNull(FipScope.getServerId(FNGRPRNT, null));
+        assertNull(FipScope.getServerId(URL, FINGERPRINT, "{ 'jenkins-instance': 'https://some.other.jenkins.io', 'jenkins-scope': 'server:d8eca2df-7795-4069-b2ef-1e2412491345' }"));
+        assertNull(FipScope.getServerId(URL, FINGERPRINT, "{ 'jenkins-identity': 'different-than-expected', 'jenkins-scope': 'server:d8eca2df-7795-4069-b2ef-1e2412491345' }"));
+        assertNull(FipScope.getServerId(URL, FINGERPRINT, "{ foo: [ 'not', 'the', 'json', 'you', 'expect' ] }"));
+        assertNull(FipScope.getServerId(URL, FINGERPRINT, "[ 'not', 'the', 'json', 'you', 'expect' ]"));
+        assertNull(FipScope.getServerId(URL, FINGERPRINT, "Human description"));
+        assertNull(FipScope.getServerId(URL, FINGERPRINT, ""));
+        assertNull(FipScope.getServerId(URL, FINGERPRINT, null));
     }
 }

--- a/plugin/src/test/java/jenkins/plugins/openstack/compute/internal/OpenstackTest.java
+++ b/plugin/src/test/java/jenkins/plugins/openstack/compute/internal/OpenstackTest.java
@@ -379,6 +379,7 @@ public class OpenstackTest {
 
         doReturn(server).when(os)._bootAndWaitActive(any(ServerCreateBuilder.class), any(Integer.class));
         doThrow(new Openstack.ActionFailed("Fake deletion failure")).when(os).destroyServer(server);
+        doNothing().when(os).attachFingerprint(any(ServerCreateBuilder.class));
 
         try {
             os.bootAndWaitActive(mock(ServerCreateBuilder.class), 1);


### PR DESCRIPTION
This is problematic for Jenkinses running on localhost, as their resource ownership clashes, and they remove each other's resources.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
