### PR TITLE
Stop using deprecated `Util#join`

### DIFF
--- a/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsBuildWrapper.java
+++ b/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsBuildWrapper.java
@@ -154,7 +154,7 @@ public class JCloudsBuildWrapper extends BuildWrapper {
             }
         }
 
-        return Util.join(ips, ",");
+        return String.join(",", ips);
     }
 
     private static void terminateNodes(Iterable<RunningNode> runningNodes) {


### PR DESCRIPTION
This method was deprecated in jenkinsci/jenkins#5467, so migrate away from it in favor of native Java Platform functionality.