### PR TITLE
Update Jenkins Version and use Jenkins Bom

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -14,7 +14,7 @@
     <url>https://github.com/jenkinsci/openstack-cloud-plugin</url>
 
     <properties>
-        <jenkins.version>2.222.4</jenkins.version>
+        <jenkins.version>2.235.4</jenkins.version>
         <java.level>8</java.level>
         <concurrency>1C</concurrency>
         <surefire.useFile>false</surefire.useFile>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -1,9 +1,23 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.289.x</artifactId>
+                <version>950.v396cb834de1e</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>4.17</version>
+        <relativePath></relativePath>
     </parent>
 
     <artifactId>openstack-cloud</artifactId>
@@ -14,7 +28,7 @@
     <url>https://github.com/jenkinsci/openstack-cloud-plugin</url>
 
     <properties>
-        <jenkins.version>2.235.4</jenkins.version>
+        <jenkins.version>2.289.1</jenkins.version>
         <java.level>8</java.level>
         <concurrency>1C</concurrency>
         <surefire.useFile>false</surefire.useFile>
@@ -27,7 +41,6 @@
         <jsr305.version>1.3.9</jsr305.version>
         <openstack4j.version>3.8</openstack4j.version>
         <okhttp.version>3.9.1</okhttp.version>
-        <configuration-as-code.version>1.38</configuration-as-code.version>
     </properties>
 
     <developers>
@@ -70,17 +83,14 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-slaves</artifactId>
-            <version>1.31.5</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-credentials</artifactId>
-            <version>1.18.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.3.14</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -95,12 +105,10 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>resource-disposer</artifactId>
-            <version>0.5</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.30</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -111,19 +119,16 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>caffeine-api</artifactId>
-            <version>2.9.1-23.v51c4e2c879c8</version>
         </dependency>
 
         <!-- Hardcoding upper-bound versions of dependencies -->
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>annotation-indexer</artifactId>
-            <version>1.12</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.50</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
@@ -138,19 +143,17 @@
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>symbol-annotation</artifactId>
-            <version>1.20</version>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.26</version>
+            <version>1.29</version>
         </dependency>
 
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
-            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -162,26 +165,28 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.25</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
             <classifier>tests</classifier>
-            <version>3.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>jenkins-test-harness</artifactId>
+            <version>1589.vc23fca066d5c</version>
             <scope>test</scope>
         </dependency>
 
@@ -189,27 +194,44 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>command-launcher</artifactId>
-            <version>1.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jdk-tool</artifactId>
-            <version>1.1</version>
             <!-- actually used from production source of ssh-slaves so cannot be test scoped -->
         </dependency>
 
         <dependency>
             <artifactId>configuration-as-code</artifactId>
             <groupId>io.jenkins</groupId>
-            <version>${configuration-as-code.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <artifactId>test-harness</artifactId>
             <groupId>io.jenkins.configuration-as-code</groupId>
-            <version>${configuration-as-code.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.12.4</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.12.4</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.12.4</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>2.12.4</version>
         </dependency>
     </dependencies>
 
@@ -219,12 +241,10 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>cobertura-maven-plugin</artifactId>
-                    <version>2.7</version> <!-- JDK 7+ support -->
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.0.0</version>
                     <configuration>
                         <additionalOptions>
                             <option>-Xdoclint:all,-missing</option>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -18,7 +18,7 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>4.25</version>
-        <relativePath></relativePath>
+        <relativePath/>
     </parent>
 
     <artifactId>openstack-cloud</artifactId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <dependencyManagement>
@@ -16,7 +17,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.17</version>
+        <version>4.25</version>
         <relativePath></relativePath>
     </parent>
 
@@ -34,20 +35,23 @@
         <surefire.useFile>false</surefire.useFile>
         <spotbugs.failOnError>false</spotbugs.failOnError>
         <spotbugs.excludeFilterFile>src/findbugs-exclude.xml</spotbugs.excludeFilterFile>
-        <spotbugs.skip>true</spotbugs.skip> <!-- Upstream Jenkins fails the build if some are found. Excludes does not seem to work. -->
+        <spotbugs.skip>true
+        </spotbugs.skip> <!-- Upstream Jenkins fails the build if some are found. Excludes does not seem to work. -->
         <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
 
         <guava.version>20.0</guava.version> <!-- version compatible with openstack4j -->
         <jsr305.version>1.3.9</jsr305.version>
-        <openstack4j.version>3.8</openstack4j.version>
+        <openstack4j.version>3.10</openstack4j.version>
         <okhttp.version>3.9.1</okhttp.version>
+        <jenkins-test-harness.version>1626.v46b0925e70db</jenkins-test-harness.version>
+        <jackson.version>2.12.4</jackson.version>
     </properties>
 
     <developers>
         <developer>
-          <id>olivergondza</id>
-          <name>Oliver Gondža</name>
-          <email>ogondza@gmail.com</email>
+            <id>olivergondza</id>
+            <name>Oliver Gondža</name>
+            <email>ogondza@gmail.com</email>
         </developer>
     </developers>
 
@@ -150,6 +154,29 @@
             <version>1.29</version>
         </dependency>
 
+        <!--Specifying jenkins version to avoid maven.plugins.enforcer.RequireUpperBoundDeps error
+        between configuration as code and openstack4j -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -183,12 +210,6 @@
             <artifactId>workflow-basic-steps</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-test-harness</artifactId>
-            <version>1589.vc23fca066d5c</version>
-            <scope>test</scope>
-        </dependency>
 
         <!-- Plugins split from core -->
         <dependency>
@@ -211,27 +232,6 @@
             <artifactId>test-harness</artifactId>
             <groupId>io.jenkins.configuration-as-code</groupId>
             <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.12.4</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>2.12.4</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.12.4</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.12.4</version>
         </dependency>
     </dependencies>
 

--- a/plugin/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
+++ b/plugin/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
@@ -35,7 +35,6 @@ import hudson.Util;
 import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
 import jenkins.plugins.openstack.compute.auth.OpenstackCredential;
-import org.apache.commons.codec.Charsets;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.jenkinsci.main.modules.instance_identity.InstanceIdentity;
@@ -94,6 +93,8 @@ import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Encapsulate {@link OSClient}.
@@ -517,7 +518,7 @@ public class Openstack {
             // Use salted hash not to disclose the public key. The key is used to authenticate agent connections.
             INSTANCE_FINGERPRINT = DigestUtils.sha1Hex(
                     "openstack-cloud-plugin-identity-fingerprint:"
-                    + new String(Base64.encodeBase64(InstanceIdentity.get().getPublic().getEncoded()), Charsets.UTF_8)
+                            + new String(Base64.encodeBase64(InstanceIdentity.get().getPublic().getEncoded()), UTF_8)
             );
         }
         return INSTANCE_FINGERPRINT;

--- a/plugin/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudTest.java
+++ b/plugin/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudTest.java
@@ -19,6 +19,7 @@ import hudson.model.UnprotectedRootAction;
 import hudson.model.User;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
+import hudson.security.AccessDeniedException3;
 import hudson.security.Permission;
 import hudson.security.SidACL;
 import hudson.slaves.Cloud;
@@ -334,7 +335,7 @@ public class JCloudsCloudTest {
         try {
             j.executeOnServer(new DoProvision(jenkinsRead, template));
             fail("Expected 'AccessDeniedException' exception hasn't been thrown");
-        } catch (AccessDeniedException ex) {
+        } catch (AccessDeniedException3 ex) {
             // Expected
         }
     }
@@ -518,7 +519,7 @@ public class JCloudsCloudTest {
             try {
                 desc.doTestConnection(true, c.getId(), destination, "");
                 fail();
-            } catch (AccessDeniedException ex) {
+            } catch (AccessDeniedException3 ex) {
                 // Expected
             }
             assertEquals(0, credentialsCollectingPortal.reqs.size());

--- a/plugin/src/test/java/jenkins/plugins/openstack/compute/slaveopts/BootSourceTest.java
+++ b/plugin/src/test/java/jenkins/plugins/openstack/compute/slaveopts/BootSourceTest.java
@@ -39,10 +39,10 @@ import org.openstack4j.model.storage.block.Volume;
 import org.openstack4j.model.storage.block.VolumeSnapshot;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import static java.util.Locale.US;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
@@ -55,7 +55,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class BootSourceTest {
-    private static final FormValidation VALIDATION_REQUIRED = FormValidation.error(hudson.util.Messages.FormValidation_ValidateRequired());
+    private static final FormValidation VALIDATION_REQUIRED = FormValidation.error(hudson.util.Messages._FormValidation_ValidateRequired().toString(US));
 
     public @Rule PluginTestRule j = new PluginTestRule();
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <version>2.61-SNAPSHOT</version>
 
     <properties>
-        <jenkins.version>2.235.4</jenkins.version>
+        <jenkins.version>2.289.1</jenkins.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <version>2.61-SNAPSHOT</version>
 
     <properties>
-        <jenkins.version>2.222.4</jenkins.version>
+        <jenkins.version>2.235.4</jenkins.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/ui-tests/pom.xml
+++ b/ui-tests/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>acceptance-test-harness</artifactId>
-            <version>1.70</version>
+            <version>1.101</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
As described in https://github.com/jenkinsci/openstack-cloud-plugin/issues/330 currently the Plugin can't be build at jenkins.io due to the enforcement of a newer jenkins version for plugins.
This Pull Request

- updates the Jenkins version
- migrates library versions to the usage of [jenkins tools bill of materials (bom)](https://mvnrepository.com/artifact/io.jenkins.tools.bom) to avoid library version incompatibilities
- fixes deprecations with for library updates
- makes BootSourceTest#doCheckImageIdWhenNoValueSet assertion default locale independ

This Pull Request replaces https://github.com/jenkinsci/openstack-cloud-plugin/pull/329 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
