### PR TITLE
ui: document default instance cap value

### DIFF
--- a/plugin/src/main/resources/jenkins/plugins/openstack/compute/SlaveOptions/help-instanceCap.html
+++ b/plugin/src/main/resources/jenkins/plugins/openstack/compute/SlaveOptions/help-instanceCap.html
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
   <div>
-    Maximal number of instances to be maintained.
+    Maximal number of instances to be maintained. By default, this value is 10.
     When specified as a global option, it will limit the total number of servers the cloud can run at one time. When specified
     on a template level it constrains the number of servers per given template. Note both the values are in effect simultaneously
     so new node will not be provisioned provided it would exceed one or the other limit.


### PR DESCRIPTION
It can be confusing to new users to find that this configuration value is already set. Explain that it is "10" out of the box.