### PR TITLE
Fix 310: Nodes failing to lunch after startTimeout are dead

### DIFF
--- a/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsComputer.java
+++ b/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsComputer.java
@@ -98,6 +98,9 @@ public class JCloudsComputer extends AbstractCloudComputer<JCloudsSlave> impleme
      */
     /*package*/ @CheckForNull OfflineCause getFatalOfflineCause() {
         OfflineCause oc = getOfflineCause();
+
+        if (getNode().isLaunchTimedOut() && oc instanceof OfflineCause.LaunchFailed) return oc;
+
         return oc instanceof DiskSpaceMonitorDescriptor.DiskSpace || oc instanceof OfflineCause.ChannelTermination
                 ? oc
                 : null

--- a/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlave.java
+++ b/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlave.java
@@ -365,6 +365,16 @@ public class JCloudsSlave extends AbstractCloudSlave implements TrackedItem {
         return created;
     }
 
+    /**
+     * @return True if the agent should have been up by now, and it is not. Note it could have been up momentarily before.
+     */
+    public boolean isLaunchTimedOut() {
+        JCloudsComputer computer = getComputer();
+        if (computer != null && computer.isOnline()) return false;
+        long existsFor = System.currentTimeMillis() - created;
+        return existsFor > getSlaveOptions().getStartTimeout();
+    }
+
     @Override public JCloudsComputer getComputer() {
         return (JCloudsComputer) super.getComputer();
     }

--- a/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
+++ b/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
@@ -223,7 +223,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 
             String cause;
             while ((cause = cloud.slaveIsWaitingFor(node)) != null) {
-                if ((System.currentTimeMillis() - node.getCreatedTime()) > timeout) {
+                if (node.isLaunchTimedOut()) {
 
                     String timeoutMessage = String.format("Failed to connect agent %s within timeout (%d ms): %s", node.getNodeName(), timeout, cause);
                     Error errorQuerying = null;


### PR DESCRIPTION
Tests where SSH failed to lunch AND the start timeout is over are considered broken and will be deleted.

Fixes https://github.com/jenkinsci/openstack-cloud-plugin/issues/310

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
