### PR TITLE
Add an option for choose the interface of ssh instead take 1rst one for multiple network

### DIFF
--- a/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsBuildWrapper.java
+++ b/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsBuildWrapper.java
@@ -90,7 +90,7 @@ public class JCloudsBuildWrapper extends BuildWrapper {
                         if (result != null) {
                             synchronized (cloudTemplateNodeBuilder) {
                                 // Builder in not threadsafe
-                                cloudTemplateNodeBuilder.add(new RunningNode(nodePlan.getCloud(), result));
+                                cloudTemplateNodeBuilder.add(new RunningNode(nodePlan.getCloud(), result, nodePlan.getSshNetWorkInterface()));
                             }
                         } else {
                             failedLaunches.incrementAndGet();
@@ -144,7 +144,7 @@ public class JCloudsBuildWrapper extends BuildWrapper {
     private @Nonnull String getIpsString(final Iterable<RunningNode> runningNodes) {
         final List<String> ips = new ArrayList<>(instancesToRun.size());
         for (RunningNode node : runningNodes) {
-            String addr = Openstack.getAccessIpAddress(node.getNode());
+            String addr = Openstack.getAccessIpAddress(node.getNode(), node.getSshNetWorkInterface());
             if (addr != null) {
                 ips.add(addr);
             } else {
@@ -168,9 +168,12 @@ public class JCloudsBuildWrapper extends BuildWrapper {
         private final String cloud;
         private final Server node;
 
-        RunningNode(String cloud, Server node) {
+        private final String sshNetWorkInterface;
+
+        RunningNode(String cloud, Server node, String sshNetWorkInterface) {
             this.cloud = cloud;
             this.node = node;
+            this.sshNetWorkInterface = sshNetWorkInterface;
         }
 
         public String getCloudName() {
@@ -179,6 +182,9 @@ public class JCloudsBuildWrapper extends BuildWrapper {
 
         public Server getNode() {
             return node;
+        }
+        public String getSshNetWorkInterface() {
+            return sshNetWorkInterface;
         }
     }
 
@@ -201,6 +207,10 @@ public class JCloudsBuildWrapper extends BuildWrapper {
 
         public String getTemplate() {
             return template.getName();
+        }
+
+        public String getSshNetWorkInterface() {
+            return template.getRawSlaveOptions().getSshNetworkInterface();
         }
 
         public int getCount() {

--- a/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlave.java
+++ b/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlave.java
@@ -97,7 +97,7 @@ public class JCloudsSlave extends AbstractCloudSlave implements TrackedItem {
         setMode(Mode.NORMAL);
         setLabelString(labelString);
         setRetentionStrategy(new JCloudsRetentionStrategy());
-        setNodeProperties(mkNodeProperties(Openstack.getAccessIpAddress(metadata), slaveOptions.getNodeProperties()));
+        setNodeProperties(mkNodeProperties(Openstack.getAccessIpAddress(metadata, slaveOptions.getSshNetworkInterface()), slaveOptions.getNodeProperties()));
         setLauncher(new JCloudsLauncher(getLauncherFactory().createLauncher(this)));
     }
 
@@ -322,7 +322,7 @@ public class JCloudsSlave extends AbstractCloudSlave implements TrackedItem {
      */
     public @CheckForNull String getPublicAddress() throws NoSuchElementException {
 
-        return Openstack.getAccessIpAddress(getOpenstack(cloudName).getServerById(nodeId));
+        return Openstack.getAccessIpAddress(getOpenstack(cloudName).getServerById(nodeId), this.getSlaveOptions().getSshNetworkInterface());
     }
 
     /**

--- a/plugin/src/main/java/jenkins/plugins/openstack/compute/SlaveOptions.java
+++ b/plugin/src/main/java/jenkins/plugins/openstack/compute/SlaveOptions.java
@@ -54,12 +54,13 @@ import java.util.Objects;
  */
 public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
     private static final long serialVersionUID = -1L;
-    private static final SlaveOptions EMPTY = new SlaveOptions(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+    private static final SlaveOptions EMPTY = new SlaveOptions(null, null,null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
 
     // Provisioning attributes
     private /*final*/ @CheckForNull BootSource bootSource;
     private final @CheckForNull String hardwareId;
     private final @CheckForNull String networkId; // csv list of networkIds, in fact
+    private final String sshNetworkInterface; //
     private final @CheckForNull String userDataId;
     private final Integer instanceCap;
     private final Integer instancesMin;
@@ -104,6 +105,10 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
 
     public @CheckForNull String getNetworkId() {
         return networkId;
+    }
+
+    public @CheckForNull String getSshNetworkInterface() {
+        return sshNetworkInterface;
     }
 
     public @CheckForNull String getUserDataId() {
@@ -165,6 +170,7 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
                 b.bootSource,
                 b.hardwareId,
                 b.networkId,
+                b.sshNetworkInterface,
                 b.userDataId,
                 b.instanceCap,
                 b.instancesMin,
@@ -188,6 +194,7 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
             @CheckForNull BootSource bootSource,
             String hardwareId,
             String networkId,
+            String sshNetworkInterface,
             String userDataId,
             Integer instanceCap,
             Integer instancesMin,
@@ -207,6 +214,7 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
         this.bootSource = bootSource;
         this.hardwareId = Util.fixEmpty(hardwareId);
         this.networkId = Util.fixEmpty(networkId);
+        this.sshNetworkInterface = Util.fixEmpty(sshNetworkInterface);
         this.userDataId = Util.fixEmpty(userDataId);
         this.instanceCap = instanceCap;
         this.instancesMin = instancesMin;
@@ -244,6 +252,7 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
                 .bootSource(_override(this.bootSource, o.bootSource))
                 .hardwareId(_override(this.hardwareId, o.hardwareId))
                 .networkId(_override(this.networkId, o.networkId))
+                .sshNetworkInterface(_override(this.sshNetworkInterface, o.sshNetworkInterface))
                 .userDataId(_override(this.userDataId, o.userDataId))
                 .instanceCap(_override(this.instanceCap, o.instanceCap))
                 .instancesMin(_override(this.instancesMin, o.instancesMin))
@@ -275,6 +284,7 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
                 .bootSource(_erase(this.bootSource, defaults.bootSource))
                 .hardwareId(_erase(this.hardwareId, defaults.hardwareId))
                 .networkId(_erase(this.networkId, defaults.networkId))
+                .sshNetworkInterface(_erase(this.sshNetworkInterface, defaults.sshNetworkInterface))
                 .userDataId(_erase(this.userDataId, defaults.userDataId))
                 .instanceCap(_erase(this.instanceCap, defaults.instanceCap))
                 .instancesMin(_erase(this.instancesMin, defaults.instancesMin))
@@ -307,6 +317,7 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
                 .append("bootSource", bootSource)
                 .append("hardwareId", hardwareId)
                 .append("networkId", networkId)
+                .append("sshNetworkInterface", sshNetworkInterface)
                 .append("userDataId", userDataId)
                 .append("instanceCap", instanceCap)
                 .append("instancesMin", instancesMin)
@@ -336,6 +347,7 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
         if (!Objects.equals(bootSource, that.bootSource)) return false;
         if (!Objects.equals(hardwareId, that.hardwareId)) return false;
         if (!Objects.equals(networkId, that.networkId)) return false;
+        if (!Objects.equals(sshNetworkInterface, that.sshNetworkInterface)) return false;
         if (!Objects.equals(userDataId, that.userDataId)) return false;
         if (!Objects.equals(instanceCap, that.instanceCap)) return false;
         if (!Objects.equals(instancesMin, that.instancesMin)) return false;
@@ -358,6 +370,7 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
         int result = bootSource != null ? bootSource.hashCode() : 0;
         result = 31 * result + (hardwareId != null ? hardwareId.hashCode() : 0);
         result = 31 * result + (networkId != null ? networkId.hashCode() : 0);
+        result = 31 * result + (sshNetworkInterface != null ? sshNetworkInterface.hashCode() : 0);
         result = 31 * result + (userDataId != null ? userDataId.hashCode() : 0);
         result = 31 * result + (instanceCap != null ? instanceCap.hashCode() : 0);
         result = 31 * result + (instancesMin != null ? instancesMin.hashCode() : 0);
@@ -384,6 +397,7 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
                 .bootSource(bootSource)
                 .hardwareId(hardwareId)
                 .networkId(networkId)
+                .sshNetworkInterface(sshNetworkInterface)
                 .userDataId(userDataId)
                 .instanceCap(instanceCap)
                 .instancesMin(instancesMin)
@@ -417,6 +431,7 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
         private @CheckForNull BootSource bootSource;
         private @CheckForNull String hardwareId;
         private @CheckForNull String networkId;
+        private @CheckForNull String sshNetworkInterface;
         private @CheckForNull String userDataId;
         private @CheckForNull Integer instanceCap;
         private @CheckForNull Integer instancesMin;
@@ -453,6 +468,11 @@ public class SlaveOptions implements Describable<SlaveOptions>, Serializable {
 
         public @Nonnull Builder networkId(String networkId) {
             this.networkId = networkId;
+            return this;
+        }
+
+        public @Nonnull Builder sshNetworkInterface(String sshNetworkInterface) {
+            this.sshNetworkInterface = sshNetworkInterface;
             return this;
         }
 

--- a/plugin/src/main/java/jenkins/plugins/openstack/pipeline/SimplifiedServer.java
+++ b/plugin/src/main/java/jenkins/plugins/openstack/pipeline/SimplifiedServer.java
@@ -27,6 +27,7 @@ public class SimplifiedServer implements Serializable {
     private @Nonnull String cloud;
     private @Nonnull String template;
     private @Nonnull String scope;
+    private @Nonnull String sshNetWorkInterface;
 
     public SimplifiedServer(@Nonnull String cloud, @Nonnull String template, @Nonnull String scope) {
         this.template = template;
@@ -37,6 +38,7 @@ public class SimplifiedServer implements Serializable {
         JCloudsCloud jcl = JCloudsCloud.getByName(cloud);
         JCloudsSlaveTemplate t = jcl.getTemplate(template);
         if (t == null) throw new IllegalArgumentException("Invalid template: " + template);
+        sshNetWorkInterface = t.getRawSlaveOptions().getSshNetworkInterface();
 
         this.srv = t.provisionServer(serverscope, null);
     }
@@ -54,7 +56,7 @@ public class SimplifiedServer implements Serializable {
     public String getAddress() {
         if (srv == null) return null;
 
-        return Openstack.getAccessIpAddress(srv);
+        return Openstack.getAccessIpAddress(srv, sshNetWorkInterface);
     }
 
     @Whitelisted

--- a/plugin/src/main/resources/jenkins/plugins/openstack/compute/SlaveOptions/config.jelly
+++ b/plugin/src/main/resources/jenkins/plugins/openstack/compute/SlaveOptions/config.jelly
@@ -24,6 +24,9 @@
                     <f:entry title="Network(s)" field="networkId">
                         <f:textbox checkMethod="post"/>
                     </f:entry>
+                    <f:entry title="Name of Network Interface for SSH" field="sshNetworkInterface">
+                        <f:textbox checkMethod="post"/>
+                    </f:entry>
                     <f:entry title="User Data" field="userDataId">
                         <f:select checkMethod="post"/>
                     </f:entry>

--- a/plugin/src/main/resources/jenkins/plugins/openstack/compute/SlaveOptions/help-sshNetworkInterface.html
+++ b/plugin/src/main/resources/jenkins/plugins/openstack/compute/SlaveOptions/help-sshNetworkInterface.html
@@ -1,0 +1,3 @@
+<div>
+  Networks Interface Jenkins will use for ssh connection on multiple network. Must be the name and not the Id. Can be empty if no preference.
+</div>

--- a/plugin/src/test/java/jenkins/plugins/openstack/PluginTestRule.java
+++ b/plugin/src/test/java/jenkins/plugins/openstack/PluginTestRule.java
@@ -126,7 +126,7 @@ public final class PluginTestRule extends JenkinsRule {
             dummyUserData("dummyUserDataId");
         }
         return new SlaveOptions(
-                new BootSource.VolumeSnapshot("id"), "hw", "nw1,mw2", "dummyUserDataId", 1, 2, "pool", "sg", "az", 1, null, 10,
+                new BootSource.VolumeSnapshot("id"), "hw", "nw1,mw2", "private_nw1","dummyUserDataId", 1, 2, "pool", "sg", "az", 1, null, 10,
                 "jvmo", "fsRoot", LauncherFactory.JNLP.JNLP, mkListOfNodeProperties(1, 2), 1, null
         );
     }

--- a/plugin/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudTest.java
+++ b/plugin/src/test/java/jenkins/plugins/openstack/compute/JCloudsCloudTest.java
@@ -142,10 +142,10 @@ public class JCloudsCloudTest {
         String openstackAuth = j.dummyCredentials();
 
         JCloudsSlaveTemplate template = new JCloudsSlaveTemplate("template", "label", new SlaveOptions(
-                new BootSource.Image("iid"), "hw", "nw", "ud", 1, 0, "public", "sg", "az", 2, "kp", 3, "jvmo", "fsRoot", LauncherFactory.JNLP.JNLP, null, 4, false
+                new BootSource.Image("iid"), "hw", "nw", "sshnw","ud", 1, 0, "public", "sg", "az", 2, "kp", 3, "jvmo", "fsRoot", LauncherFactory.JNLP.JNLP, null, 4, false
         ));
         JCloudsCloud cloud = new JCloudsCloud("openstack", "endPointUrl", false,"zone", new SlaveOptions(
-                new BootSource.VolumeSnapshot("vsid"), "HW", "NW", "UD", 6, 4, null, "SG", "AZ", 7, "KP", 8, "JVMO", "FSrOOT", new LauncherFactory.SSH("cid"), null, 9, false
+                new BootSource.VolumeSnapshot("vsid"), "HW", "NW", "SSHNW", "UD", 6, 4, null, "SG", "AZ", 7, "KP", 8, "JVMO", "FSrOOT", new LauncherFactory.SSH("cid"), null, 9, false
         ), Collections.singletonList(template),openstackAuth);
         j.jenkins.clouds.add(cloud);
 

--- a/plugin/src/test/java/jenkins/plugins/openstack/compute/SlaveOptionsTest.java
+++ b/plugin/src/test/java/jenkins/plugins/openstack/compute/SlaveOptionsTest.java
@@ -27,6 +27,7 @@ public class SlaveOptionsTest {
         assertEquals(new BootSource.VolumeSnapshot("id"), unmodified.getBootSource());
         assertEquals("hw", unmodified.getHardwareId());
         assertEquals("nw1,mw2", unmodified.getNetworkId());
+        assertEquals("private_nw1", unmodified.getSshNetworkInterface());
         assertEquals("dummyUserDataId", unmodified.getUserDataId());
         assertEquals(1, (int) unmodified.getInstanceCap());
         assertEquals(2, (int) unmodified.getInstancesMin());
@@ -46,6 +47,7 @@ public class SlaveOptionsTest {
                 .bootSource(new BootSource.Image("iid"))
                 .hardwareId("HW")
                 .networkId("NW")
+                .sshNetworkInterface("PRIVATE_NW")
                 .userDataId("UD")
                 .instanceCap(42)
                 .instancesMin(0)
@@ -67,6 +69,7 @@ public class SlaveOptionsTest {
         assertEquals(new BootSource.Image("iid"), overridden.getBootSource());
         assertEquals("HW", overridden.getHardwareId());
         assertEquals("NW", overridden.getNetworkId());
+        assertEquals("PRIVATE_NW", overridden.getSshNetworkInterface());
         assertEquals("UD", overridden.getUserDataId());
         assertEquals(42, (int) overridden.getInstanceCap());
         assertEquals(0, (int) overridden.getInstancesMin());
@@ -99,11 +102,12 @@ public class SlaveOptionsTest {
     public void emptyStrings() {
         SlaveOptions nulls = SlaveOptions.empty();
         SlaveOptions emptyStrings = new SlaveOptions(
-                null, "", "", "", null, null, "", "", "", null, "", null, "", "", null, null, null, null
+                null, "", "", "","", null, null, "", "", "", null, "", null, "", "", null, null, null, null
         );
         SlaveOptions emptyBuilt = SlaveOptions.builder()
                 .hardwareId("")
                 .networkId("")
+                .sshNetworkInterface("")
                 .userDataId("")
                 .floatingIpPool("")
                 .securityGroups("")
@@ -118,6 +122,7 @@ public class SlaveOptionsTest {
 
         assertEquals(null, emptyStrings.getHardwareId());
         assertEquals(null, emptyStrings.getNetworkId());
+        assertEquals(null, emptyStrings.getSshNetworkInterface());
         assertEquals(null, emptyStrings.getUserDataId());
         assertEquals(null, emptyStrings.getSecurityGroups());
         assertEquals(null, emptyStrings.getAvailabilityZone());


### PR DESCRIPTION
Add a option for choose the network for ssh Connection by his openstack name.

Related Jira Issues : [Unable to create a VM with multiple networks](https://issues.jenkins.io/browse/JENKINS-40325)
