### PR TITLE
make cleanup and pre-creation recurrence period configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ credentials:
 -   On every agent provisioned by the plugin, there is an environment
     variable `OPENSTACK_PUBLIC_IP` declared with the public IP address
     allocated for the machine.
+-   Default recurrence period for thread cleaning up agents is 10 minutes, for thread pre-creating node it is 2 minutes. These values can be modified by setting new values in milliseconds in system properties `jenkins.openstack.cleanupPeriod` and `jenkins.openstack.preCreationPeriod`. This is particularly useful in combinations with single-use agents (agents with 1 executor and retention time set to `0`) for Jenkins installation with quick and often executed jobs.
 
 ### Troubleshooting
 

--- a/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsCleanupThread.java
+++ b/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsCleanupThread.java
@@ -26,6 +26,8 @@ import hudson.model.TaskListener;
 import org.openstack4j.api.exceptions.ClientResponseException;
 import org.openstack4j.api.exceptions.StatusCode;
 import org.openstack4j.model.compute.Server;
+import java.util.concurrent.TimeUnit;
+
 
 import javax.annotation.Nonnull;
 
@@ -41,14 +43,17 @@ import javax.annotation.Nonnull;
 @Extension @Restricted(NoExternalUse.class)
 public final class JCloudsCleanupThread extends AsyncPeriodicWork {
     private static final Logger LOGGER = Logger.getLogger(JCloudsCleanupThread.class.getName());
+    private final Long recurrencePeriod;
 
     public JCloudsCleanupThread() {
         super("OpenStack slave cleanup");
+        recurrencePeriod = Long.getLong("jenkins.openstack.cleanupPeriod", TimeUnit.MINUTES.toMillis(10));
+        LOGGER.log(Level.FINE, "OpenStack cleanup recurrence period is {0}ms", recurrencePeriod);
     }
 
     @Override
     public long getRecurrencePeriod() {
-        return MIN * 10;
+        return recurrencePeriod;
     }
 
     @Override

--- a/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsPreCreationThread.java
+++ b/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsPreCreationThread.java
@@ -13,6 +13,8 @@ import hudson.Extension;
 import hudson.Functions;
 import hudson.model.TaskListener;
 import hudson.model.AsyncPeriodicWork;
+import java.util.concurrent.TimeUnit;
+
 
 /**
  * Periodically ensure enough slaves are created.
@@ -37,14 +39,17 @@ import hudson.model.AsyncPeriodicWork;
 @Extension @Restricted(NoExternalUse.class)
 public final class JCloudsPreCreationThread extends AsyncPeriodicWork {
     private static final Logger LOGGER = Logger.getLogger(JCloudsPreCreationThread.class.getName());
+    private final Long recurrencePeriod;
 
     public JCloudsPreCreationThread() {
         super("OpenStack slave pre-creation");
+        recurrencePeriod = Functions.getIsUnitTest() ? Long.MAX_VALUE : Long.getLong("jenkins.openstack.preCreationPeriod", TimeUnit.MINUTES.toMillis(2));
+        LOGGER.log(Level.FINE, "OpenStack pre-creation recurrence period is {0}ms", recurrencePeriod);
     }
 
     @Override
     public long getRecurrencePeriod() {
-        return Functions.getIsUnitTest() ? Long.MAX_VALUE : MIN * 2;
+        return recurrencePeriod;
     }
 
     @Override


### PR DESCRIPTION
This PR allows Jenkins operator to configure the recurrence period for cleanup and pre-creation threads.

This allows to faster cleanup and pre-creating machines, I find this setting particular useful in scenario where openstack agents are single-use (1 executor, 0 retention time) and combined with set of quick jobs (less than 1 minute or so) that are often executed. It may lead to situation when openstack plugin is not able to create new machines due to hitting limit but at the same time the already existing machines are marked for termination filling up quota. In worst case almost 10 min to get cleanup and freed limit.

Implementation has been inspired by [same issue in ec2 jenkins plugin](https://github.com/jenkinsci/ec2-plugin/blob/master/src/main/java/hudson/plugins/ec2/EC2SlaveMonitor.java#L28-L34) 

This PR relates to https://github.com/jenkinsci/openstack-cloud-plugin/issues/282

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

