### PR TITLE
Fix #56: Introduce backoff for provisioning

### DIFF
--- a/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
+++ b/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
@@ -245,7 +245,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
                     }
                     throw ex;
                 }
-                LOGGER.info("Exponential backoff delay of next slave provisioning attempt in " + backOffOnFailureSeconds + " seconds");
+                LOGGER.info("Exponential backoff delay of next agent provisioning attempt in " + backOffOnFailureSeconds + " seconds");
                 Thread.sleep(backOffOnFailureSeconds * 1000L);
                 if (backOffOnFailureSeconds < BACKOFF_ON_FAILURE_LIMIT) { // keep doubling sleep factor in seconds until we reach five minute delay
                     backOffOnFailureSeconds = backOffOnFailureSeconds * 2;

--- a/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
+++ b/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplate.java
@@ -214,6 +214,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
     ) throws JCloudsCloud.ProvisioningFailedException {
         SlaveOptions opts = getEffectiveSlaveOptions();
         int timeout = opts.getStartTimeout();
+        int backOffOnFailureSeconds = 2;
         Server server = provisionServer(null, id);
 
         JCloudsSlave node = null;
@@ -244,7 +245,10 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
                     throw ex;
                 }
 
-                Thread.sleep(2000);
+                Thread.sleep(backOffOnFailureSeconds * 1000L);
+                if (backOffOnFailureSeconds < 60 * 5) { // keep doubling sleep factor in seconds until we reach five minute delay
+                    backOffOnFailureSeconds = backOffOnFailureSeconds * 2;
+                }
             }
 
             return node;


### PR DESCRIPTION
Perhaps this might help with https://github.com/jenkinsci/openstack-cloud-plugin/issues/56 in that on provisioning failure we do [exponential backoff](https://en.m.wikipedia.org/wiki/Exponential_backoff) until we reach a certain delay point (e.g. currently hard coded to 5 minutes but that could change to whatever delay we prefer or use configuration settings for).

<!-- Please describe your pull request here. -->

We will initially try connecting again after failure following a schedule like:

2 second sleep before trying again.
4 second sleep before trying again.
8 second sleep before trying again.
16 second sleep before trying again.
32 second sleep before trying again.
64 second sleep before trying again.
...
Until we reach a delay/sleep of 5 minutes or higher and will then continue to sleep after each failure until we reach the timeout.  

The advantage of this approach is we will use less of the Jenkins machine CPU due to the increasing backoff delay/sleep time.

1.  The `jenkins.plugins.openstack.agentProvisioningBackoffOnFailureInitialSeconds` parameter overrides the initial setting (default: `2 second`) sleep performed after the first provisioning failure.  Note that a successful provisioning followed by another failure, will again use this setting to go through the exponential backoff delay sequencing again.
2. The `jenkins.plugins.openstack.agentProvisioningBackOffLimit` parameter overrides the max delay (default: `5 minutes`) for sleep delay after provisioning failures.   

Related (currently open) pull requests:

https://github.com/jenkinsci/openstack-cloud-plugin/pull/351 is for introducing a provisioning delay "jenkins.plugins.openstack.agentProvisioningDelaySeconds" option, which, when passed to Jenkins JVM, delays requests for deployment of each individual VM by a given amount of seconds.  While my preference is to add exponential backoff via https://github.com/jenkinsci/openstack-cloud-plugin/pull/365, there may also be specific use cases where `jenkins.plugins.openstack.agentProvisioningDelaySeconds ` can help better (e.g. to reduce the overall amount of CPU used for provisioning.)  So I think both are needed.  

Thanks for your time and review.


### Testing done

Just passed unit tests.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
