### PR TITLE
Clean VM frequency is configurable

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -35,7 +35,7 @@
     <url>https://github.com/jenkinsci/openstack-cloud-plugin</url>
 
     <properties>
-        <jenkins.version>2.414.1</jenkins.version>
+        <jenkins.version>2.419</jenkins.version>
         <java.level>11</java.level>
         <concurrency>1C</concurrency>
         <surefire.useFile>false</surefire.useFile>
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloud-stats</artifactId>
-            <version>320.v96b_65297a_4b_b_</version>
+            <version>336.v788e4055508b_</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsCleanupThread.java
+++ b/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsCleanupThread.java
@@ -48,11 +48,15 @@ public final class JCloudsCleanupThread extends AsyncPeriodicWork {
 
     @Override
     public long getRecurrencePeriod() {
-        return MIN * 10;
+        // fixed value: 1000 millis
+        long cleanFreq = 1000;
+
+        return cleanFreq;
     }
 
     @Override
     public void execute(TaskListener listener) {
+
         try {
             terminateNodesPendingDeletion();
 
@@ -61,6 +65,9 @@ public final class JCloudsCleanupThread extends AsyncPeriodicWork {
             terminatesNodesWithoutServers(runningServers);
 
             cleanOrphanedFips();
+
+            setCloudLastCleanTime();
+
         } catch (JCloudsCloud.LoginFailure ex) {
             LOGGER.log(Level.WARNING, "Unable to authenticate: " + ex.getMessage());
         } catch (Throwable ex) {
@@ -70,6 +77,7 @@ public final class JCloudsCleanupThread extends AsyncPeriodicWork {
 
     private void cleanOrphanedFips() {
         for (JCloudsCloud cloud : JCloudsCloud.getClouds()) {
+            if ((System.currentTimeMillis() - cloud.getLastCleanTime()) < cloud.getCleanfreqToMillis()) continue;
             Openstack openstack = cloud.getOpenstack();
 
             List<String> leaked = openstack.getFreeFipIds();
@@ -87,8 +95,17 @@ public final class JCloudsCleanupThread extends AsyncPeriodicWork {
         }
     }
 
+    private void setCloudLastCleanTime() {
+            for (JCloudsCloud cloud : JCloudsCloud.getClouds()) {
+                if ((System.currentTimeMillis() - cloud.getLastCleanTime()) < cloud.getCleanfreqToMillis()) continue;
+                cloud.setLastCleanTime(System.currentTimeMillis());
+            }
+    }
+
     private void terminateNodesPendingDeletion() {
         for (final JCloudsComputer comp : JCloudsComputer.getAll()) {
+            JCloudsCloud cloud = JCloudsCloud.getByName(comp.getId().getCloudName());
+            if ((System.currentTimeMillis() - cloud.getLastCleanTime()) < cloud.getCleanfreqToMillis()) continue;
             if (!comp.isIdle()) continue;
 
             final OfflineCause offlineCause = comp.getNode().getFatalOfflineCause();
@@ -156,6 +173,7 @@ public final class JCloudsCleanupThread extends AsyncPeriodicWork {
     private @Nonnull HashMap<JCloudsCloud, List<Server>> destroyServersOutOfScope() {
         HashMap<JCloudsCloud, List<Server>> runningServers = new HashMap<>();
         for (JCloudsCloud jc : JCloudsCloud.getClouds()) {
+            if ((System.currentTimeMillis() - jc.getLastCleanTime()) < jc.getCleanfreqToMillis()) continue;
             runningServers.put(jc, new ArrayList<>());
             List<Server> servers = jc.getOpenstack().getRunningNodes();
             for (Server server : servers) {
@@ -175,6 +193,9 @@ public final class JCloudsCleanupThread extends AsyncPeriodicWork {
     private void terminatesNodesWithoutServers(@Nonnull HashMap<JCloudsCloud, List<Server>> runningServers) {
         Map<String, JCloudsComputer> jenkinsComputers = new HashMap<>();
         for (JCloudsComputer computer: JCloudsComputer.getAll()) {
+            JCloudsCloud cloud = JCloudsCloud.getByName(computer.getId().getCloudName());
+            if ((System.currentTimeMillis() - cloud.getLastCleanTime()) < cloud.getCleanfreqToMillis()) continue;
+
             JCloudsSlave node = computer.getNode();
             if (node != null) {
                 jenkinsComputers.put(node.getServerId(), computer);

--- a/plugin/src/main/java/jenkins/plugins/openstack/compute/OsAuthDescriptor.java
+++ b/plugin/src/main/java/jenkins/plugins/openstack/compute/OsAuthDescriptor.java
@@ -94,7 +94,7 @@ public abstract class OsAuthDescriptor<DESCRIBABLE extends Describable<DESCRIBAB
 
         // Replace direct reference to references to possible relative paths
         if (method.getAnnotation(InjectOsAuth.class) != null) {
-            for (String attr: Arrays.asList("endPointUrl", "ignoreSsl", "credentialsId", "zone")) {
+            for (String attr: Arrays.asList("endPointUrl", "ignoreSsl", "credentialsId", "zone", "cleanfreq")) {
                 deps.remove(attr);
                 for (String offset : getAuthFieldsOffsets()) {
                     deps.add(offset + "/" + attr);

--- a/plugin/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
+++ b/plugin/src/main/java/jenkins/plugins/openstack/compute/internal/Openstack.java
@@ -141,7 +141,7 @@ public class Openstack {
             = Caffeine.newBuilder().expireAfterWrite(5, TimeUnit.SECONDS).build()
     ;
 
-    private Openstack(@Nonnull String endPointUrl, boolean ignoreSsl, @Nonnull OpenstackCredential auth, @CheckForNull String region) {
+    private Openstack(@Nonnull String endPointUrl, boolean ignoreSsl, @Nonnull OpenstackCredential auth, @CheckForNull String region, @Nonnull long cleanfreq) {
 
         final IOSClientBuilder<? extends OSClient<?>, ?> builder = auth.getBuilder(endPointUrl);
 
@@ -880,19 +880,19 @@ public class Openstack {
         ;
 
         public abstract @Nonnull Openstack getOpenstack(
-                @Nonnull String endPointUrl, boolean ignoreSsl, @Nonnull OpenstackCredential openstackCredential, @CheckForNull String region
+                @Nonnull String endPointUrl, boolean ignoreSsl, @Nonnull OpenstackCredential openstackCredential, @CheckForNull String region, @Nonnull long cleanfreq
         ) throws FormValidation;
 
         /**
          * Instantiate Openstack client.
          */
         public static @Nonnull Openstack get(
-                @Nonnull final String endPointUrl, final boolean ignoreSsl, @Nonnull final OpenstackCredential auth, @CheckForNull final String region
+                @Nonnull final String endPointUrl, final boolean ignoreSsl, @Nonnull final OpenstackCredential auth, @CheckForNull final String region, @Nonnull final long cleanfreq
         ) throws FormValidation {
             final FactoryEP ep = ExtensionList.lookup(FactoryEP.class).get(0);
             final Function<String, Openstack> cacheMissFunction = (String unused) -> {
                 try {
-                    return ep.getOpenstack(endPointUrl, ignoreSsl, auth, region);
+                    return ep.getOpenstack(endPointUrl, ignoreSsl, auth, region, cleanfreq);
                 } catch (FormValidation ex) {
                     throw new RuntimeException(ex);
                 }
@@ -949,14 +949,14 @@ public class Openstack {
 
     @Extension
     public static final class Factory extends FactoryEP {
-        public @Nonnull Openstack getOpenstack(@Nonnull String endPointUrl, boolean ignoreSsl, @Nonnull OpenstackCredential auth, @CheckForNull String region) throws FormValidation {
+        public @Nonnull Openstack getOpenstack(@Nonnull String endPointUrl, boolean ignoreSsl, @Nonnull OpenstackCredential auth, @CheckForNull String region, @Nonnull long cleanfreq) throws FormValidation {
             endPointUrl = Util.fixEmptyAndTrim(endPointUrl);
             region = Util.fixEmptyAndTrim(region);
 
             if (endPointUrl == null) throw FormValidation.error("No endPoint specified");
             if (auth == null) throw FormValidation.error("No credential specified");
 
-            return new Openstack(endPointUrl, ignoreSsl, auth, region);
+            return new Openstack(endPointUrl, ignoreSsl, auth, region, cleanfreq);
         }
     }
 

--- a/plugin/src/main/java/jenkins/plugins/openstack/compute/slaveopts/LauncherFactory.java
+++ b/plugin/src/main/java/jenkins/plugins/openstack/compute/slaveopts/LauncherFactory.java
@@ -257,6 +257,7 @@ public abstract class LauncherFactory extends AbstractDescribableImpl<LauncherFa
 
         @Override
         public ComputerLauncher createLauncher(@Nonnull JCloudsSlave slave) throws IOException {
+            terminated = false;
             Jenkins.get().addNode(slave);
             return new JNLPLauncher(false);
         }

--- a/plugin/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/config.jelly
+++ b/plugin/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/config.jelly
@@ -11,11 +11,14 @@
     </f:entry>
     <f:entry title="Credential" field="credentialsId">
         <c:select/>
-     </f:entry>
+    </f:entry>
     <f:entry title="Region" field="zone">
         <f:textbox/>
     </f:entry>
-    <f:validateButton title="Test Connection" progress="${%Testing...}" method="testConnection" with="endPointUrl,ignoreSsl,credentialsId,zone"/>
+    <f:entry title="Cleanup frequency (seconds)" field="cleanfreq">
+        <f:number min="10" max="1200" default="10"/>
+    </f:entry>
+    <f:validateButton title="Test Connection" progress="${%Testing...}" method="testConnection" with="endPointUrl,ignoreSsl,credentialsId,zone,cleanfreq"/>
 
     <f:advanced title="Default slave options">
         <j:set var="defaultOpts" value="${descriptor.defaultOptions}"/>

--- a/plugin/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/help-cleanfreq.html
+++ b/plugin/src/main/resources/jenkins/plugins/openstack/compute/JCloudsCloud/help-cleanfreq.html
@@ -1,0 +1,3 @@
+<div>
+  Clean frequency of pending VM (seconds)
+</div>

--- a/plugin/src/test/java/jenkins/plugins/openstack/PluginTestRule.java
+++ b/plugin/src/test/java/jenkins/plugins/openstack/PluginTestRule.java
@@ -469,7 +469,7 @@ public final class PluginTestRule extends JenkinsRule {
         Openstack.FactoryEP.replace(new Openstack.FactoryEP() {
             @Override
             public @Nonnull Openstack getOpenstack(
-                    @Nonnull String endPointUrl, boolean ignoreSsl, @Nonnull OpenstackCredential openstackCredential, @CheckForNull String region
+                    @Nonnull String endPointUrl, boolean ignoreSsl, @Nonnull OpenstackCredential openstackCredential, @CheckForNull String region, @Nonnull long cleanfreq
             ) {
                 return os;
             }
@@ -487,9 +487,9 @@ public final class PluginTestRule extends JenkinsRule {
 
             @Override
             public @Nonnull Openstack getOpenstack(
-                    @Nonnull String endpointUrl, boolean ignoreSsl, @Nonnull OpenstackCredential openstackCredential, String region
+                    @Nonnull String endpointUrl, boolean ignoreSsl, @Nonnull OpenstackCredential openstackCredential, String region, long cleanfreq
             ) throws FormValidation {
-                return factory.getOpenstack(endpointUrl, ignoreSsl, openstackCredential, region);
+                return factory.getOpenstack(endpointUrl, ignoreSsl, openstackCredential, region, cleanfreq);
             }
         });
         return factory;
@@ -641,7 +641,7 @@ public final class PluginTestRule extends JenkinsRule {
         }
 
         public MockJCloudsCloud(SlaveOptions opts, JCloudsSlaveTemplate... templates) {
-            super("openstack", "endPointUrl", false,"zone", opts, Arrays.asList(templates), "credentialsId");
+            super("openstack", "endPointUrl", false,"zone", 2, opts, Arrays.asList(templates), "credentialsId");
         }
 
         @Override

--- a/plugin/src/test/java/jenkins/plugins/openstack/compute/JCloudsRetentionStrategyTest.java
+++ b/plugin/src/test/java/jenkins/plugins/openstack/compute/JCloudsRetentionStrategyTest.java
@@ -79,6 +79,7 @@ public class JCloudsRetentionStrategyTest {
                 j.defaultSlaveOptions().getBuilder().retentionTime(1 /*disposable asap*/).build(),
                 "label"
         )));
+        cloud.setCleanfreq(5);
         cloud.provision(Label.get("label"), 1);
 
         do {

--- a/plugin/src/test/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplateTest.java
+++ b/plugin/src/test/java/jenkins/plugins/openstack/compute/JCloudsSlaveTemplateTest.java
@@ -78,6 +78,7 @@ public class JCloudsSlaveTemplateTest {
 
         JCloudsCloud originalCloud = new JCloudsCloud(
                 "my-openstack", "endPointUrl", false, "zone",
+                10000,
                 SlaveOptions.empty(),
                 Arrays.asList(jnlpTemplate, sshTemplate),
                 j.dummyCredentials()
@@ -90,7 +91,7 @@ public class JCloudsSlaveTemplateTest {
         j.submit(form);
 
         final JCloudsCloud actualCloud = JCloudsCloud.getByName("my-openstack");
-        j.assertEqualBeans(originalCloud, actualCloud, "name,credentialsId,zone");
+        j.assertEqualBeans(originalCloud, actualCloud, "name,credentialsId,zone,cleanfreq");
         assertThat(actualCloud.getEffectiveSlaveOptions(), equalTo(originalCloud.getEffectiveSlaveOptions()));
         assertThat(actualCloud.getRawSlaveOptions(), equalTo(originalCloud.getRawSlaveOptions()));
 
@@ -117,6 +118,7 @@ public class JCloudsSlaveTemplateTest {
 
         JCloudsCloud cloud = new JCloudsCloud(
                 "my-openstack", "credential", false, "zone",
+                10000,
                 cloudOpts,
                 singletonList(template),
                 j.dummyCredentials()

--- a/plugin/src/test/java/jenkins/plugins/openstack/compute/SingleUseSlaveTest.java
+++ b/plugin/src/test/java/jenkins/plugins/openstack/compute/SingleUseSlaveTest.java
@@ -82,6 +82,7 @@ public class SingleUseSlaveTest {
                 j.defaultSlaveOptions().getBuilder().retentionTime(0).instancesMin(1).build(),
                 "label"
         )));
+        cloud.setCleanfreq(20); // the clean should not happen during the test
         JCloudsSlave slave = j.provision(cloud, "label");
         JCloudsComputer computer = slave.getComputer();
         computer.waitUntilOnline();
@@ -102,7 +103,9 @@ public class SingleUseSlaveTest {
                 j.defaultSlaveOptions().getBuilder().retentionTime(0).instancesMin(0).build(),
                 "label"
         )));
+        cloud.setCleanfreq(2);
         JCloudsSlave slave = j.provision(cloud, "label");
+        Thread.sleep(3000);
         verifyOneOffContract(slave);
     }
 
@@ -112,6 +115,7 @@ public class SingleUseSlaveTest {
                 j.defaultSlaveOptions().getBuilder().retentionTime(0).instancesMin(1).build(),
                 "label"
         )));
+        cloud.setCleanfreq(2);
         JCloudsSlave slave = j.provision(cloud, "label");
         verifyOneOffContract(slave);
     }
@@ -128,6 +132,7 @@ public class SingleUseSlaveTest {
         j.buildAndAssertSuccess(p);
 
         j.waitUntilNoActivity();
+        Thread.sleep(3000);
         j.triggerOpenstackSlaveCleanup();
 
         assertThat(JCloudsComputer.getAll(), emptyIterable());
@@ -136,7 +141,7 @@ public class SingleUseSlaveTest {
     @Test
     public void preserveAgentOfflineByUser() throws Exception {
         j.configureSlaveLaunchingWithFloatingIP(j.dummyCloud(j.dummySlaveTemplate(
-                j.defaultSlaveOptions().getBuilder().retentionTime(0).instancesMin(1).build(),
+                j.defaultSlaveOptions().getBuilder().retentionTime(0).instancesMin(1).instanceCap(1).build(),
                 "label"
         )));
         FreeStyleProject p = j.createFreeStyleProject();

--- a/plugin/src/test/java/jenkins/plugins/openstack/compute/slaveopts/BootSourceTest.java
+++ b/plugin/src/test/java/jenkins/plugins/openstack/compute/slaveopts/BootSourceTest.java
@@ -106,7 +106,7 @@ public class BootSourceTest {
 
         doReturn(Collections.singletonMap(imageName, Collections.singletonList(image))).when(os).getImages();
 
-        ListBoxModel list = id.doFillNameItems("", "OSurl", false, credentialsId, "OSzone");
+        ListBoxModel list = id.doFillNameItems("", "OSurl", false, credentialsId, "OSzone", 10000);
         assertEquals(2, list.size());
         assertEquals("First menu entry is 'nothing selected'", "", list.get(0).value);
         ListBoxModel.Option item = list.get(1);
@@ -125,7 +125,7 @@ public class BootSourceTest {
         Openstack os = j.fakeOpenstackFactory();
         when(os.getVolumeSnapshots()).thenReturn(Collections.singletonMap("vs-name", Collections.singletonList(volumeSnapshot)));
 
-        ListBoxModel list = vsd.doFillNameItems("existing-vs-name", "OSurl", false, credentialsId, "OSzone");
+        ListBoxModel list = vsd.doFillNameItems("existing-vs-name", "OSurl", false, credentialsId, "OSzone", 10000);
         assertEquals(3, list.size());
         assertEquals("First menu entry is 'nothing selected'", "", list.get(0).value);
         assertEquals("Second menu entry is the VS OpenStack can see", "vs-name", list.get(1).name);
@@ -148,7 +148,7 @@ public class BootSourceTest {
         j.fakeOpenstackFactory(new Openstack(osClient));
         final String credentialsId = j.dummyCredentials();
 
-        ListBoxModel list = id.doFillNameItems("", "OSurl", false, credentialsId, "OSzone");
+        ListBoxModel list = id.doFillNameItems("", "OSurl", false, credentialsId, "OSzone", 10000);
         assertThat(list.get(0).name, list, Matchers.iterableWithSize(2));
         assertEquals(2, list.size());
         ListBoxModel.Option item = list.get(1);
@@ -167,7 +167,7 @@ public class BootSourceTest {
         final String credentialsIdCloud = j.dummyCredentials();
         final String credentialsIdTemplate = j.dummyCredentials();
 
-        final FormValidation actual = id.doCheckName("", urlC, urlT, false, false, credentialsIdCloud, credentialsIdTemplate, zoneC, zoneT);
+        final FormValidation actual = id.doCheckName("", urlC, urlT, false, false, credentialsIdCloud, credentialsIdTemplate, zoneC, zoneT, 10000, 10000);
         assertThat(actual, j.validateAs(VALIDATION_REQUIRED));
     }
 
@@ -183,7 +183,7 @@ public class BootSourceTest {
         j.fakeOpenstackFactory(os);
         final FormValidation expected = FormValidation.error("Not found");
 
-        final FormValidation actual = id.doCheckName("imageNotFound", urlC, urlT, false, false, credentialsIdCloud, credentialsIdTemplate, zoneC, zoneT);
+        final FormValidation actual = id.doCheckName("imageNotFound", urlC, urlT, false, false, credentialsIdCloud, credentialsIdTemplate, zoneC, zoneT, 10000, 10000);
         assertThat(actual, j.validateAs(expected));
     }
 
@@ -198,7 +198,7 @@ public class BootSourceTest {
         j.fakeOpenstackFactory(os);
         final FormValidation expected = FormValidation.ok();
 
-        final FormValidation actual = id.doCheckName("imageFound", urlC, urlT, false, false, credentialsIdCloud, credentialsIdTemplate, zoneC, zoneT);
+        final FormValidation actual = id.doCheckName("imageFound", urlC, urlT, false, false, credentialsIdCloud, credentialsIdTemplate, zoneC, zoneT, 10000, 10000);
         assertThat(actual, j.validateAs(expected));
     }
 
@@ -213,7 +213,7 @@ public class BootSourceTest {
         j.fakeOpenstackFactory(os);
         final FormValidation expected = FormValidation.warning("Multiple matching results");
 
-        final FormValidation actual = id.doCheckName("imageAmbiguous", urlC, urlT, false, false, credentialsIdCloud, credentialsIdTemplate, zoneC, zoneT);
+        final FormValidation actual = id.doCheckName("imageAmbiguous", urlC, urlT, false, false, credentialsIdCloud, credentialsIdTemplate, zoneC, zoneT, 10000, 10000);
         assertThat("imageAmbiguous", actual, j.validateAs(expected));
     }
 
@@ -228,7 +228,7 @@ public class BootSourceTest {
         j.fakeOpenstackFactory(os);
         final FormValidation expected = FormValidation.ok();
 
-        final FormValidation actual = vsd.doCheckName("vsFound", urlC, urlT, false, false, credentialsIdCloud, credentialsIdTemplate, zoneC, zoneT);
+        final FormValidation actual = vsd.doCheckName("vsFound", urlC, urlT, false, false, credentialsIdCloud, credentialsIdTemplate, zoneC, zoneT, 10000, 10000);
         assertThat("vsFound", actual, j.validateAs(expected));
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done: 

@msegura helped me to test over an Openstack cloud:
* the Cleanfreq input
* CASC
* frequency cleaning

 UI modification screenshot:

![cleanfreq](https://github.com/user-attachments/assets/c2e1921c-a0d4-49b8-b552-d3835b52911a)

Unit tests have been modified with the cleanfreq parameter.

Relevant feature: https://github.com/jenkinsci/openstack-cloud-plugin/issues/392

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

