### PR TITLE
Catch getByName exception in case cloud name is not an openstack cloud

### DIFF
--- a/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsCleanupThread.java
+++ b/plugin/src/main/java/jenkins/plugins/openstack/compute/JCloudsCleanupThread.java
@@ -101,8 +101,11 @@ public final class JCloudsCleanupThread extends AsyncPeriodicWork {
 
     private void terminateNodesPendingDeletion() {
         for (final JCloudsComputer comp : JCloudsComputer.getAll()) {
-            JCloudsCloud cloud = JCloudsCloud.getByName(comp.getId().getCloudName());
-            if ((System.currentTimeMillis() - cloud.getLastCleanTime()) < cloud.getCleanfreqToMillis()) continue;
+            try {
+                JCloudsCloud cloud = JCloudsCloud.getByName(comp.getId().getCloudName());
+                if ((System.currentTimeMillis() - cloud.getLastCleanTime()) < cloud.getCleanfreqToMillis()) continue;
+            } catch (IllegalArgumentException e) {
+            }
             if (!comp.isIdle()) continue;
 
             final OfflineCause offlineCause = comp.getNode().getFatalOfflineCause();
@@ -195,8 +198,11 @@ public final class JCloudsCleanupThread extends AsyncPeriodicWork {
     private void terminatesNodesWithoutServers(@Nonnull HashMap<JCloudsCloud, List<Server>> runningServers) {
         Map<String, JCloudsComputer> jenkinsComputers = new HashMap<>();
         for (JCloudsComputer computer : JCloudsComputer.getAll()) {
-            JCloudsCloud cloud = JCloudsCloud.getByName(computer.getId().getCloudName());
-            if ((System.currentTimeMillis() - cloud.getLastCleanTime()) < cloud.getCleanfreqToMillis()) continue;
+            try {
+                JCloudsCloud cloud = JCloudsCloud.getByName(computer.getId().getCloudName());
+                if ((System.currentTimeMillis() - cloud.getLastCleanTime()) < cloud.getCleanfreqToMillis()) continue;
+            } catch (IllegalArgumentException e) {
+            }
 
             JCloudsSlave node = computer.getNode();
             if (node != null) {


### PR DESCRIPTION
Fix the following NPE:

```
java.lang.IllegalArgumentException: 'openstack' is not an OpenStack cloud but null
	at jenkins.plugins.openstack.compute.JCloudsCloud.getByName(JCloudsCloud.java:128)
	at jenkins.plugins.openstack.compute.JCloudsCleanupThread.terminateNodesPendingDeletion(JCloudsCleanupThread.java:104)
	at jenkins.plugins.openstack.compute.JCloudsCleanupThread.execute(JCloudsCleanupThread.java:55)
	at hudson.model.AsyncPeriodicWork.lambda$doRun$0(AsyncPeriodicWork.java:102)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
