### PR TITLE
Migrate from Commons Lang 2 to Commons Lang 3

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -101,6 +101,10 @@
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>caffeine-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-lang3-api</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>io.jenkins.plugins</groupId>

--- a/plugin/src/main/java/jenkins/plugins/openstack/compute/SlaveOptions.java
+++ b/plugin/src/main/java/jenkins/plugins/openstack/compute/SlaveOptions.java
@@ -37,7 +37,7 @@ import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 import jenkins.plugins.openstack.compute.slaveopts.BootSource;
 import jenkins.plugins.openstack.compute.slaveopts.LauncherFactory;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;

--- a/plugin/src/main/java/jenkins/plugins/openstack/compute/internal/TokenGroup.java
+++ b/plugin/src/main/java/jenkins/plugins/openstack/compute/internal/TokenGroup.java
@@ -26,7 +26,7 @@ package jenkins.plugins.openstack.compute.internal;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 


### PR DESCRIPTION
Migrate from deprecated/EOL Commons Lang 2 to Commons Lang 3.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

## What's changed

- Renamed the `org.apache.commons.lang.*` imports to `org.apache.commons.lang3.*` in the `plugin`
  module and declared `io.jenkins.plugins:commons-lang3-api` there (`ToStringBuilder` and
  `StringUtils.strip` have no clean JDK equivalent).

### Testing done

`mvn -B -ntp clean verify` runs the suite; one test errors on my machine, which also happens
without this change.

The `ban-commons-lang-2` enforcer rule was left disabled: it needs parent POM `6.2116.v7501b_67dc517` or newer and this plugin is on `5.17`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact @timja.
